### PR TITLE
Adding Jest as test framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@microsoft/tsdoc": "^0.14.2",
         "@rdfjs/types": "^1.1.0",
         "@types/crypto-js": "^4.1.1",
+        "@types/jest": "^29.2.4",
         "@types/node": "^18.11.2",
         "@types/yargs": "^17.0.13",
         "@typescript-eslint/eslint-plugin": "^5.42.1",
@@ -32,7 +33,9 @@
         "jest": "^29.3.1",
         "jest-extended": "^3.1.0",
         "jest-mock-extended": "^3.0.1",
+        "jest-runner-groups": "^2.2.0",
         "lerna": "^6.0.1",
+        "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.4"
       }
@@ -2885,6 +2888,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "29.2.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.4.tgz",
+      "integrity": "sha512-PipFB04k2qTRPePduVLTRiPzQfvMeLwUN3Z21hsAKaB/W9IIzgB2pizCL466ftJlcyZqnHoC9ZHpxLGl3fS86A==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -3837,6 +3850,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -8327,6 +8352,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-runner-groups": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jest-runner-groups/-/jest-runner-groups-2.2.0.tgz",
+      "integrity": "sha512-Sp/B9ZX0CDAKa9dIkgH0sGyl2eDuScV4SVvOxqhBMxqWpsNAkmol/C58aTFmPWZj+C0ZTW1r1BSu66MTCN+voA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "jest-docblock": ">= 24",
+        "jest-runner": ">= 24"
+      }
+    },
     "node_modules/jest-runner/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8909,6 +8947,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+      "dev": true
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -12084,6 +12128,70 @@
         "typescript": ">=3.7.0"
       }
     },
+    "node_modules/ts-jest": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.3.tgz",
+      "integrity": "sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.1",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ts-jest/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -15110,6 +15218,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "29.2.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.4.tgz",
+      "integrity": "sha512-PipFB04k2qTRPePduVLTRiPzQfvMeLwUN3Z21hsAKaB/W9IIzgB2pizCL466ftJlcyZqnHoC9ZHpxLGl3fS86A==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -15783,6 +15901,15 @@
         "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.9"
+      }
+    },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -19146,6 +19273,13 @@
         }
       }
     },
+    "jest-runner-groups": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jest-runner-groups/-/jest-runner-groups-2.2.0.tgz",
+      "integrity": "sha512-Sp/B9ZX0CDAKa9dIkgH0sGyl2eDuScV4SVvOxqhBMxqWpsNAkmol/C58aTFmPWZj+C0ZTW1r1BSu66MTCN+voA==",
+      "dev": true,
+      "requires": {}
+    },
     "jest-runtime": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.3.1.tgz",
@@ -19614,6 +19748,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
     },
     "lodash.merge": {
@@ -22011,6 +22151,36 @@
       "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
       "dev": true,
       "requires": {}
+    },
+    "ts-jest": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.3.tgz",
+      "integrity": "sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.1",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "^21.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
     },
     "ts-node": {
       "version": "10.9.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,30 @@
   "bugs": {
     "url": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/issues"
   },
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "testRegex": "/test/.*.test.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "index.js"
+    ],
+    "testEnvironment": "node",
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
+  },
   "scripts": {
     "test-changed": "lerna run test --since HEAD",
     "build-changed": "lerna run build --since HEAD",
@@ -19,6 +43,7 @@
     "build-watch": "tsc --watch",
     "lint": "eslint . --ext .ts --cache",
     "lint:fix": "eslint . --ext .ts --cache --fix",
+    "test": "npm run test:unit && npm run test:integration",
     "test:unit": "lerna run test:unit",
     "test:integration": "lerna run test:integration"
   },
@@ -26,6 +51,7 @@
     "@microsoft/tsdoc": "^0.14.2",
     "@rdfjs/types": "^1.1.0",
     "@types/crypto-js": "^4.1.1",
+    "@types/jest": "^29.2.4",
     "@types/node": "^18.11.2",
     "@types/yargs": "^17.0.13",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
@@ -41,7 +67,9 @@
     "jest": "^29.3.1",
     "jest-extended": "^3.1.0",
     "jest-mock-extended": "^3.0.1",
+    "jest-runner-groups": "^2.2.0",
     "lerna": "^6.0.1",
+    "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
   },

--- a/packages/oslo-converter-uml-ea/package.json
+++ b/packages/oslo-converter-uml-ea/package.json
@@ -18,7 +18,28 @@
     "type": "git",
     "url": "git+https://github.com/Informatievlaanderen/OSLO-UML-Transformer.git"
   },
-  "scripts": {},
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "testRegex": "/test/.*.test.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "index.js"
+    ],
+    "testEnvironment": "node"
+  },
+  "scripts": {
+    "build": "npm run build:ts",
+    "build:ts": "tsc",
+    "test:integration": "node \"../../node_modules/jest/bin/jest.js\" --group=integration",
+    "test:unit": "node \"../../node_modules/jest/bin/jest.js\" --group=unit"
+  },
   "bugs": {
     "url": "https://github.com/Informatievlaanderen/OSLO-UML-Transformer/issues"
   },

--- a/packages/oslo-converter-uml-ea/test/EaUmlConversionService.integration.test.ts
+++ b/packages/oslo-converter-uml-ea/test/EaUmlConversionService.integration.test.ts
@@ -1,0 +1,7 @@
+/**
+ * @group integration
+ */
+
+describe('EaUmlConversionService', () => {
+  console.log('Integration tests coming soon');
+});

--- a/packages/oslo-core/package-lock.json
+++ b/packages/oslo-core/package-lock.json
@@ -1,0 +1,264 @@
+{
+  "name": "@oslo-flanders/core",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@oslo-flanders/core",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/tmp": "^0.2.3",
+        "tmp": "^0.2.1"
+      }
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@types/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  }
+}

--- a/packages/oslo-core/package.json
+++ b/packages/oslo-core/package.json
@@ -16,7 +16,28 @@
     "type": "git",
     "url": "git+https://github.com/Informatievlaanderen/OSLO-UML-Transformer.git"
   },
-  "scripts": {},
+  "jest": {
+    "runner": "groups",
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "testRegex": "/test/.*.test.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "index.js"
+    ],
+    "testEnvironment": "node"
+  },
+  "scripts": {
+    "build": "npm run build:ts",
+    "build:ts": "tsc",
+    "test:unit": "node \"../../node_modules/jest/bin/jest.js\" --group=unit"
+  },
   "bugs": {
     "url": "https://github.com/Informatievlaanderen/OSLO-UML-Transformer/issues"
   },

--- a/packages/oslo-core/test/Logger.unit.test.ts
+++ b/packages/oslo-core/test/Logger.unit.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @group unit
+ */
+import 'reflect-metadata';
+import { BaseLogger } from '../lib/logging/Logger';
+
+describe('Logger', () => {
+  describe('a BaseLogger', () => {
+    let logger: BaseLogger;
+
+    beforeEach(() => {
+      logger = new (<any>BaseLogger)();
+      logger.log = jest.fn();
+    });
+
+    it('delegates error to log.', async (): Promise<void> => {
+      logger.error('my message');
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith('error', 'my message');
+    });
+
+    it('warn delegates to log.', async (): Promise<void> => {
+      logger.warn('my message');
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith('warn', 'my message');
+    });
+
+    it('info delegates to log.', async (): Promise<void> => {
+      logger.info('my message');
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith('info', 'my message');
+    });
+
+    it('verbose delegates to log.', async (): Promise<void> => {
+      logger.verbose('my message');
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith('verbose', 'my message');
+    });
+
+    it('debug delegates to log.', async (): Promise<void> => {
+      logger.debug('my message');
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith('debug', 'my message');
+    });
+
+    it('silly delegates to log.', async (): Promise<void> => {
+      logger.silly('my message');
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith('silly', 'my message');
+    });
+  });
+});

--- a/packages/oslo-core/test/Utils.unit.test.ts
+++ b/packages/oslo-core/test/Utils.unit.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @group unit
+ */
+import { fileSync } from 'tmp';
+import { fetchFileOrUrl } from '../lib/utils/fetchFileOrUrl';
+import { uniqueId } from '../lib/utils/uniqueId';
+
+describe('Util functions', () => {
+  it('should fetch a URL and return a Buffer', async () => {
+    // eslint-disable-next-line max-len
+    const url = 'https://github.com/Informatievlaanderen/OSLO-UML-Transformer/blob/integration-test-files/oslo-converter-uml-ea/01-AssociatiesMijnDomein.EAP?raw=true';
+    expect(await fetchFileOrUrl(url)).toBeInstanceOf(Buffer);
+  });
+
+  it('should fetch a local file and return a Buffer', async () => {
+    const tmpFile = fileSync();
+    const tmpFileWithPrefix = `file://${tmpFile.name}`;
+
+    expect(await fetchFileOrUrl(tmpFile.name)).toBeInstanceOf(Buffer);
+    expect(await fetchFileOrUrl(tmpFileWithPrefix)).toBeInstanceOf(Buffer);
+  });
+
+  it('should throw an error when a local file does not exist', async () => {
+    await expect(() => fetchFileOrUrl('nonExistingFile.EAP')).rejects.toThrow(Error);
+  });
+
+  it('should generate a unique id', async () => {
+    const guid = 'test-guid';
+    const label = 'test-label';
+    const id = 1;
+
+    expect(uniqueId(guid, label, id)).toEqual(uniqueId(guid, label, id));
+    expect(uniqueId(guid, label, id)).not.toEqual(uniqueId(guid, label, 2));
+  });
+});

--- a/packages/oslo-core/test/VoidLogger.unit.test.ts
+++ b/packages/oslo-core/test/VoidLogger.unit.test.ts
@@ -1,0 +1,16 @@
+/**
+ * @group unit
+*/
+import 'reflect-metadata';
+import { VoidLogger } from '../lib/logging/VoidLogger';
+
+describe('VoidLogger', () => {
+  let logger: VoidLogger;
+  beforeEach(async (): Promise<void> => {
+    logger = new VoidLogger();
+  });
+
+  it('does nothing when log is invoked', () => {
+    expect(logger.log('debug', 'my message')).toBe(logger);
+  });
+});

--- a/packages/oslo-core/test/WinstonLogger.unit.test.ts
+++ b/packages/oslo-core/test/WinstonLogger.unit.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @group unit
+*/
+import 'reflect-metadata';
+import { WinstonLogger } from '../lib/logging/WinstonLogger';
+
+describe('WinstonLogger', () => {
+  let logger: WinstonLogger;
+  let spy: any;
+  beforeEach(async (): Promise<void> => {
+    logger = new (<any>WinstonLogger)('info');
+    spy = jest.spyOn((<any>logger).logger, 'log');
+  });
+
+  it('delegates log invocations to the inner logger', () => {
+    expect(logger.log('debug', 'my message')).toBe(logger);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('debug', 'my message');
+  });
+});

--- a/packages/oslo-extractor-uml-ea/package.json
+++ b/packages/oslo-extractor-uml-ea/package.json
@@ -28,7 +28,9 @@
     "collectCoverage": true,
     "coveragePathIgnorePatterns": [
       "/node_modules/",
-      "index.js"
+      "index.js",
+      "./lib/utils",
+      "./lib/types"
     ],
     "testEnvironment": "node"
   },

--- a/packages/oslo-extractor-uml-ea/package.json
+++ b/packages/oslo-extractor-uml-ea/package.json
@@ -16,7 +16,27 @@
     "type": "git",
     "url": "git+https://github.com/Informatievlaanderen/OSLO-UML-Transformer.git"
   },
-  "scripts": {},
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "testRegex": "/test/.*.test.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "index.js"
+    ],
+    "testEnvironment": "node"
+  },
+  "scripts": {
+    "build": "npm run build:ts",
+    "build:ts": "tsc",
+    "test:unit": "node \"../../node_modules/jest/bin/jest.js\" --group=unit"
+  },
   "bugs": {
     "url": "https://github.com/Informatievlaanderen/OSLO-UML-Transformer/issues"
   },

--- a/packages/oslo-extractor-uml-ea/test/DataRegistry.unit.test.ts
+++ b/packages/oslo-extractor-uml-ea/test/DataRegistry.unit.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @group unit
+ */
+import { VoidLogger } from '@oslo-flanders/core';
+import { DataRegistry } from '../lib/DataRegistry';
+import { EaDiagram } from '../lib/types/EaDiagram';
+import * as attributes from '../lib/utils/loadAttributes';
+import * as diagrams from '../lib/utils/loadDiagrams';
+import * as connectors from '../lib/utils/loadElementConnectors';
+import * as elements from '../lib/utils/loadElements';
+import * as packages from '../lib/utils/loadPackage';
+
+describe('DataRegistry', () => {
+  let dataRegistry: DataRegistry;
+
+  beforeEach(() => {
+    dataRegistry = new DataRegistry(new VoidLogger());
+  });
+
+  it('should throw an error when items in the data registry are not set', () => {
+    expect(() => dataRegistry.diagrams).toThrowError();
+    expect(() => dataRegistry.packages).toThrowError();
+    expect(() => dataRegistry.attributes).toThrowError();
+    expect(() => dataRegistry.elements).toThrowError();
+    expect(() => dataRegistry.connectors).toThrowError();
+    expect(() => dataRegistry.normalizedConnectors).toThrowError();
+    expect(() => dataRegistry.targetDiagram).toThrowError();
+  });
+
+  it('should return items when they are set', () => {
+    dataRegistry.diagrams = [];
+    expect(dataRegistry.diagrams).toStrictEqual([]);
+
+    dataRegistry.packages = [];
+    expect(dataRegistry.packages).toStrictEqual([]);
+
+    dataRegistry.attributes = [];
+    expect(dataRegistry.attributes).toStrictEqual([]);
+
+    dataRegistry.elements = [];
+    expect(dataRegistry.elements).toStrictEqual([]);
+
+    dataRegistry.connectors = [];
+    expect(dataRegistry.connectors).toStrictEqual([]);
+
+    dataRegistry.normalizedConnectors = [];
+    expect(dataRegistry.normalizedConnectors).toStrictEqual([]);
+
+    const mockDiagram = new EaDiagram(1, 'TestDiagram', 'guid', 1);
+
+    dataRegistry.targetDiagram = mockDiagram;
+    expect(dataRegistry.targetDiagram).toEqual(mockDiagram);
+  });
+
+  it('should be able to set the target diagram in the data registry', () => {
+    const mockDiagram = new EaDiagram(1, 'TestDiagram', 'guid', 1);
+    dataRegistry.diagrams = [mockDiagram];
+
+    dataRegistry.setTargetDiagram('TestDiagram');
+
+    expect(dataRegistry.targetDiagram).toEqual(mockDiagram);
+  });
+
+  it('should be able to set the target diagram in the data registry only once', () => {
+    const mockDiagram = new EaDiagram(1, 'TestDiagram', 'guid', 1);
+    const anotherMockDiagram = new EaDiagram(1, 'NewTestDiagram', 'guid', 1);
+    dataRegistry.diagrams = [mockDiagram, anotherMockDiagram];
+
+    dataRegistry.setTargetDiagram('TestDiagram');
+    expect(() => dataRegistry.setTargetDiagram('NewTestDiagram')).toThrowError();
+  });
+
+  it('should throw an error when a diagram can not be found set while setting the target diagram', () => {
+    const mockDiagram = new EaDiagram(1, 'TestDiagram', 'guid', 1);
+    dataRegistry.diagrams = [mockDiagram];
+
+    expect(() => dataRegistry.setTargetDiagram('TargetDiagram')).toThrowError();
+  });
+
+  it('should throw an error when multiple diagrams with the same name are found', () => {
+    const mockDiagram = new EaDiagram(1, 'TestDiagram', 'guid1', 1);
+    const anotherMockDiagram = new EaDiagram(2, 'TestDiagram', 'guid2', 1);
+    dataRegistry.diagrams = [mockDiagram, anotherMockDiagram];
+
+    expect(() => dataRegistry.setTargetDiagram('TestDiagram')).toThrowError();
+  });
+
+  it('should extract all the data from an UML diagram', async () => {
+    const packageSpy = jest.spyOn(packages, 'loadPackages');
+    const diagramSpy = jest.spyOn(diagrams, 'loadDiagrams');
+    const elementSpy = jest.spyOn(elements, 'loadElements');
+    const attributeSpy = jest.spyOn(attributes, 'loadAttributes');
+    const connectorSpy = jest.spyOn(connectors, 'loadElementConnectors');
+
+    // eslint-disable-next-line max-len
+    await dataRegistry.extract('https://github.com/Informatievlaanderen/OSLO-UML-Transformer/blob/integration-test-files/oslo-converter-uml-ea/01-AssociatiesMijnDomein.EAP?raw=true');
+
+    expect(packageSpy).toHaveBeenCalled();
+    expect(elementSpy).toHaveBeenCalled();
+    expect(diagramSpy).toHaveBeenCalled();
+    expect(attributeSpy).toHaveBeenCalled();
+    expect(connectorSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/oslo-output-handlers/package.json
+++ b/packages/oslo-output-handlers/package.json
@@ -16,7 +16,27 @@
     "type": "git",
     "url": "git+https://github.com/Informatievlaanderen/OSLO-UML-Transformer.git"
   },
-  "scripts": {},
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "testRegex": "/test/.*.test.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "index.js"
+    ],
+    "testEnvironment": "node"
+  },
+  "scripts": {
+    "build": "npm run build:ts",
+    "build:ts": "tsc",
+    "test:unit": "node \"../../node_modules/jest/bin/jest.js\" --group=unit"
+  },
   "bugs": {
     "url": "https://github.com/Informatievlaanderen/OSLO-UML-Transformer/issues"
   },

--- a/packages/oslo-output-handlers/test/JsonLdOutputHandler.unit.test.ts
+++ b/packages/oslo-output-handlers/test/JsonLdOutputHandler.unit.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @group unit
+ */
+import * as N3 from 'n3';
+import { DataFactory } from 'rdf-data-factory';
+import { JsonLdOutputHandler } from '../lib/JsonLdOutputHandler';
+
+describe('JsonLdOutputHandler', () => {
+  let store: N3.Store;
+  let df: DataFactory;
+  let outputHandler: JsonLdOutputHandler;
+
+  beforeEach(() => {
+    store = new N3.Store();
+    df = new DataFactory();
+    outputHandler = new JsonLdOutputHandler();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "importHelpers": false,
     "strict": true,
     "esModuleInterop": true,
-    "types": ["reflect-metadata", "node"],
+    "types": ["reflect-metadata", "node", "jest"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },


### PR DESCRIPTION
This PR includes the following additions:
- Jest in configured in every package as the test framework
- Every package.json contains a unit and/or integration test script
- Integration tests for `oslo-converter-uml-ea` still need to be added. Once the intermediary result is fully complete, these integration tests can be added
- Util functions in `oslo-extractor-uml-ea` are not tested (yet) and are ignored in the coverage results. In the future, unit tests must be added for these functions as well.
