### PR TITLE
Update log messages + utils functions in converter

### DIFF
--- a/packages/oslo-converter-uml-ea/lib/converterHandlers/AttributeConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converterHandlers/AttributeConverterHandler.ts
@@ -44,7 +44,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
       const attributeClass = model.elements.find(x => x.id === attribute.classId);
 
       if (!attributeClass) {
-        throw new Error(`Unable to find domain for attribute with EA guid ${attribute.eaGuid}.`);
+        throw new Error(`[AttributeConverterHandler]: Unable to find domain for attribute with EA guid ${attribute.eaGuid}.`);
       }
 
       let attributeBaseUri: URL;
@@ -54,16 +54,16 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
         const referencedPackages = uriRegistry.packageNameToPackageMap.get(packageTagValue);
 
         if (referencedPackages && referencedPackages.length > 1) {
-          this.logger.warn(`[AttributeConverterHandler]: Multiple packages discovered through name tag "${packageTagValue}".`);
+          this.logger.warn(`[AttributeConverterHandler]: Multiple packages discovered through name tag "${packageTagValue}" for attribute (${attribute.path}).`);
         }
 
         if (!referencedPackages) {
-          throw new Error(`[ElementConverterHandler]: Package tag was defined, but unable to find the objects.`);
+          throw new Error(`[AttributeConverterHandler]: Package tag was defined, but unable to find the objects for attribute (${attribute.path}).`);
         }
 
         attributeBaseUri = uriRegistry.packageIdUriMap.get(referencedPackages[0].packageId)!;
       } else if (!uriRegistry.packageIdUriMap.has(attributeClass.packageId)) {
-        throw new Error(`Unable to determine the package of attribute with EA guid ${attribute.eaGuid}.`);
+        throw new Error(`[AttributeConverterHandler]: Unable to determine the package of attribute (${attribute.path}).`);
       } else {
         attributeBaseUri = uriRegistry.packageIdUriMap.get(attributeClass.packageId)!;
       }
@@ -94,7 +94,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
     const attributeUri = uriRegistry.attributeIdUriMap.get(object.id);
 
     if (!attributeUri) {
-      throw new Error(`Attribute with EA guid ${object.eaGuid} was not assigned a URI.`);
+      throw new Error(`[AttributeConverterHandler]: Unable to find URI for attribute (${object.path}).`);
     }
 
     const attributeUriNamedNode = this.df.namedNode(attributeUri.toString());
@@ -138,7 +138,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
     }
 
     if (!rangeUri) {
-      throw new Error(`Unable to get the URI for the range of attribute with EA guid ${object.eaGuid}`);
+      throw new Error(`[AttributeConverterHandler]: Unable to get the URI for the range of attribute (${object.path}).`);
     }
 
     const rangeUriNamedNode = this.df.namedNode(rangeUri);
@@ -188,7 +188,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
     const packageBaseUri = uriRegistry.packageIdUriMap.get(model.targetDiagram.packageId);
 
     if (!packageBaseUri) {
-      throw new Error(`Unnable to find URI for the package (EA guid: ${model.targetDiagram.eaGuid}) containing the target diagram when converting EaAttributes.`);
+      throw new Error(`[AttributeCOnverterHandler]: Unable to find the URI for the package in which the target diagram (${model.targetDiagram.name}) was placed.`);
     }
 
     const scope = this.getScope(object, packageBaseUri.toString(), uriRegistry.attributeIdUriMap);

--- a/packages/oslo-converter-uml-ea/lib/converterHandlers/PackageConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converterHandlers/PackageConverterHandler.ts
@@ -41,7 +41,7 @@ export class PackageConverterHandler extends ConverterHandler<EaPackage> {
       let packageUri = getTagValue(packageObject, TagNames.PackageBaseUri, null);
 
       if (!packageUri) {
-        this.logger.warn(`[PackageConverterHandler]: No value found for tag "baseUri" in package with EA guid ${packageObject.eaGuid}.`);
+        this.logger.warn(`[PackageConverterHandler]: No value found for tag "baseUri" in package (${packageObject.path}).`);
         packageUri = uriRegistry.fallbackBaseUri;
       }
 
@@ -61,11 +61,11 @@ export class PackageConverterHandler extends ConverterHandler<EaPackage> {
     const baseUri = uriRegistry.packageIdUriMap.get(object.packageId);
 
     if (!ontologyUri) {
-      throw new Error(`Package with EA guid ${object.eaGuid} has no URI assigned.`);
+      throw new Error(`[PackageConverterHandler]: Unable to find ontology URI for package (${object.path}).`);
     }
 
     if (!baseUri) {
-      throw new Error(`Package with EA guid ${object.eaGuid} has no base URI set.`);
+      throw new Error(`[PackageConverterHandler]: Unable to find base URI for package (${object.path}).`);
     }
 
     const ontologyUriNamedNode = this.df.namedNode(ontologyUri.toString());

--- a/packages/oslo-converter-uml-ea/lib/interfaces/ConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/interfaces/ConverterHandler.ts
@@ -41,9 +41,11 @@ export abstract class ConverterHandler<T extends EaObject> {
   public abstract filterIgnoredObjects(model: DataRegistry): Promise<DataRegistry>;
 
   public getLabel(object: T): RDF.Literal[] {
-    return this.config.specificationType === 'ApplicationProfile' ?
+    const labelTags = this.config.specificationType === 'ApplicationProfile' ?
       this.getLanguageDependentTag(object, TagNames.ApLabel, TagNames.Label) :
       this.getLanguageDependentTag(object, TagNames.Label);
+
+    return labelTags.length > 0 ? labelTags : [this.df.literal(object.name)];
   }
 
   public getDefinition(object: T): RDF.Literal[] {

--- a/packages/oslo-converter-uml-ea/lib/utils/utils.ts
+++ b/packages/oslo-converter-uml-ea/lib/utils/utils.ts
@@ -23,6 +23,7 @@ export function getTagValue(object: any, tagName: TagNames, _default: any): stri
   return tags[0].tagValue;
 }
 
+// TODO: this function should be removed and logic should be part of connectors
 export function extractUri(object: EaObject, packageUri: URL, casing?: CasingTypes): URL {
   const uri = getTagValue(object, TagNames.ExternalUri, null);
 
@@ -30,7 +31,6 @@ export function extractUri(object: EaObject, packageUri: URL, casing?: CasingTyp
     return new URL(uri);
   }
 
-  // TODO: If object.name is returned, then no casing should be applied?
   let localName = getTagValue(object, TagNames.LocalName, null);
 
   if (!localName) {

--- a/packages/oslo-extractor-uml-ea/lib/types/NormalizedConnector.ts
+++ b/packages/oslo-extractor-uml-ea/lib/types/NormalizedConnector.ts
@@ -35,10 +35,6 @@ export class NormalizedConnector extends EaObject {
     this._originalId = originalConnector.id;
     this._originalType = originalConnector.type;
 
-    if (!tags.some(x => x.tagName === 'name') && name) {
-      this.addNameTag(name);
-    }
-
     this.osloGuid = uniqueId(originalConnector.eaGuid, name, sourceObjectId);
   }
 
@@ -67,19 +63,5 @@ export class NormalizedConnector extends EaObject {
 
   public get type(): NormalizedConnectorTypes {
     return this._type;
-  }
-
-  private addNameTag(name: string): void {
-    const tag: EaTag = {
-      id: Math.random(),
-      tagName: 'name',
-      tagValue: name,
-    };
-
-    if (this.tags.some(x => x.tagName === 'name')) {
-      return;
-    }
-
-    this.tags = [...this.tags, tag];
   }
 }


### PR DESCRIPTION
- Log/error messages now contain a prefix indicating the handler who is logging the message
- Refactored createQuads function in converter handlers
- Normalized connector does not create a name tag anymore in its constructor → When creating the local name we check for the name tag and return the connector name if no name tag was defined
- Updated getLabel function → Checks for ap-label and label, but now return the name of the  objects when these tags are not present