### PR TITLE
Bug fixes + optimizations

### DIFF
--- a/packages/oslo-converter-uml-ea/README.md
+++ b/packages/oslo-converter-uml-ea/README.md
@@ -17,5 +17,4 @@ The service is executed from the CLI and expects the following parameters:
 | `--outputFile` | The name of the RDF output file | No, but if omitted, output is written to process.stdout ||
 | `--specificationType` | The type of the specification | :heavy_check_mark: | `ApplicationProfile` or `Vocabulary` |
 | `--versionId` | Version identifier for the document | :heavy_check_mark: ||
-| `--baseUri` | The base URI that must be used within the document | :heavy_check_mark: ||
 | `--outputFormat` | RDF content-type specifiying the output format | :heavy_check_mark: | `application/ld+json` |

--- a/packages/oslo-converter-uml-ea/lib/EaUmlConversionService.ts
+++ b/packages/oslo-converter-uml-ea/lib/EaUmlConversionService.ts
@@ -48,7 +48,10 @@ export class EaUmlConversionService implements IService {
 
   private async addDocumentInformation(store: QuadStore): Promise<QuadStore> {
     const df = new DataFactory();
-    const versionUri = `${this.configuration.baseUri}/${this.configuration.versionId}`;
+    const normalizedVersionBaseUri = this.configuration.publicationEnvironment.endsWith('/') ?
+      this.configuration.publicationEnvironment.slice(0, -1) :
+      this.configuration.publicationEnvironment;
+    const versionUri = `${normalizedVersionBaseUri}/${this.configuration.versionId}`;
 
     // The output handler will use this quad to set the id of the document
     store.addQuad(

--- a/packages/oslo-converter-uml-ea/lib/EaUmlConversionServiceRunner.ts
+++ b/packages/oslo-converter-uml-ea/lib/EaUmlConversionServiceRunner.ts
@@ -22,7 +22,6 @@ export class EaUmlConversionServiceRunner extends AppRunner<EaUmlConversionServi
           choices: ['ApplicationProfile', 'Vocabulary'],
         })
       .option('versionId', { describe: 'Relative URI used to identify this document.' })
-      .option('baseUri', { describe: 'The base URI to be used within the document and to create the version URI.' })
       .option('outputFormat',
         {
           describe: 'RDF content-type in which the output must be written or to the console.',

--- a/packages/oslo-converter-uml-ea/lib/config/EaUmlConverterConfiguration.ts
+++ b/packages/oslo-converter-uml-ea/lib/config/EaUmlConverterConfiguration.ts
@@ -31,11 +31,6 @@ export class EaUmlConverterConfiguration implements IConfiguration {
   private _versionId: string | undefined;
 
   /**
-   * Base URI used for the version id in the RDF document
-   */
-  private _baseUri: string | undefined;
-
-  /**
    * An RDF serialisation
    */
   private _outputFormat: string | undefined;
@@ -51,7 +46,6 @@ export class EaUmlConverterConfiguration implements IConfiguration {
     this._specificationType = <string>params.specificationType;
     this._outputFile = <string>(params.outputFile || 'report.jsonld');
     this._versionId = <string>params.versionId;
-    this._baseUri = <string>params.baseUri;
     this._outputFormat = <string>params.outputFormat;
     this._publicationEnvironment = <string>params.publicationEnvironment;
   }
@@ -89,13 +83,6 @@ export class EaUmlConverterConfiguration implements IConfiguration {
       throw new Error(`Trying to access property "versionId" before it was set.`);
     }
     return this._versionId;
-  }
-
-  public get baseUri(): string {
-    if (!this._baseUri) {
-      throw new Error(`Trying to access property "baseUri" before it was set.`);
-    }
-    return this._baseUri;
   }
 
   public get outputFormat(): string {

--- a/packages/oslo-converter-uml-ea/lib/converterHandlers/ElementConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converterHandlers/ElementConverterHandler.ts
@@ -89,7 +89,7 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
 
   public createQuads(object: EaElement, uriRegistry: UriRegistry, model: DataRegistry): RDF.Quad[] {
     const quads: RDF.Quad[] = [];
-    const objectWellKnownId = this.df.namedNode(`${this.config.baseUri}/.well-known/id/${object.osloGuid}`);
+    const objectInternalId = this.df.namedNode(`${this.baseUrnScheme}:${object.osloGuid}`);
     const objectUri = uriRegistry.elementIdUriMap.get(object.id);
 
     if (!objectUri) {
@@ -110,17 +110,17 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
 
     quads.push(
       this.df.quad(
-        objectWellKnownId,
+        objectInternalId,
         ns.example('assignedUri'),
         objectUriNamedNode,
       ),
     );
 
     const definitionValues = this.getDefinition(object);
-    definitionValues.forEach(value => quads.push(this.df.quad(objectWellKnownId, ns.rdfs('comment'), value)));
+    definitionValues.forEach(value => quads.push(this.df.quad(objectInternalId, ns.rdfs('comment'), value)));
 
     const usageNoteValues = this.getUsageNote(object);
-    usageNoteValues.forEach(value => quads.push(this.df.quad(objectWellKnownId, ns.vann('usageNote'), value)));
+    usageNoteValues.forEach(value => quads.push(this.df.quad(objectInternalId, ns.vann('usageNote'), value)));
 
     const packageBaseUri = uriRegistry.packageIdUriMap.get(model.targetDiagram.packageId);
 
@@ -131,22 +131,22 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
     const scope = this.getScope(object, packageBaseUri.toString(), uriRegistry.elementIdUriMap);
 
     quads.push(this.df.quad(
-      objectWellKnownId,
+      objectInternalId,
       ns.example('scope'),
       this.df.literal(scope),
     ));
 
     switch (object.type) {
       case ElementType.Class:
-        quads.push(...this.createClassSpecificQuads(object, objectWellKnownId, uriRegistry, model));
+        quads.push(...this.createClassSpecificQuads(object, objectInternalId, uriRegistry, model));
         break;
 
       case ElementType.DataType:
-        quads.push(...this.createDataTypeSpecificQuads(object, objectWellKnownId, uriRegistry, model));
+        quads.push(...this.createDataTypeSpecificQuads(object, objectInternalId, uriRegistry, model));
         break;
 
       case ElementType.Enumeration:
-        quads.push(...this.createEnumerationSpecificQuads(object, objectWellKnownId, uriRegistry, model));
+        quads.push(...this.createEnumerationSpecificQuads(object, objectInternalId, uriRegistry, model));
         break;
 
       default:
@@ -158,7 +158,7 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
 
   private createClassSpecificQuads(
     object: EaElement,
-    objectWellKnownId: RDF.NamedNode,
+    objectInternalId: RDF.NamedNode,
     uriRegistry: UriRegistry,
     model: DataRegistry,
   ): RDF.Quad[] {
@@ -166,14 +166,14 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
 
     quads.push(
       this.df.quad(
-        objectWellKnownId,
+        objectInternalId,
         ns.rdf('type'),
         ns.owl('Class'),
       ),
     );
 
     const labelLiterals = this.getLabel(object);
-    labelLiterals.forEach(x => quads.push(this.df.quad(objectWellKnownId, ns.rdfs('label'), x)));
+    labelLiterals.forEach(x => quads.push(this.df.quad(objectInternalId, ns.rdfs('label'), x)));
 
     // Connectors array is used here, because NormalizedConnectors array doesn't have this type
     const parentClassConnectors = model.connectors
@@ -186,13 +186,13 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
         throw new Error(`[ElementConverterHandler]: Unable to find parent class for class (${object.path}).`);
       }
 
-      const parentWellKnownId = this.df.namedNode(`${this.config.baseUri}/.well-known/id/${parentClassObject.osloGuid}`);
+      const parentInternalId = this.df.namedNode(`${this.baseUrnScheme}:${parentClassObject.osloGuid}`);
 
       quads.push(
         this.df.quad(
-          objectWellKnownId,
+          objectInternalId,
           ns.rdfs('subClassOf'),
-          parentWellKnownId,
+          parentInternalId,
         ),
       );
 
@@ -215,7 +215,7 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
           this.df.quad(
             statementBlankNode,
             ns.rdf('subject'),
-            objectWellKnownId,
+            objectInternalId,
           ),
           this.df.quad(
             statementBlankNode,
@@ -225,7 +225,7 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
           this.df.quad(
             statementBlankNode,
             ns.rdf('object'),
-            parentWellKnownId,
+            parentInternalId,
           ),
           this.df.quad(
             statementBlankNode,
@@ -244,7 +244,7 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
 
   private createDataTypeSpecificQuads(
     object: EaElement,
-    objectWellKnownId: RDF.NamedNode,
+    objectInternalId: RDF.NamedNode,
     uriRegistry: UriRegistry,
     model: DataRegistry,
   ): RDF.Quad[] {
@@ -252,21 +252,21 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
 
     quads.push(
       this.df.quad(
-        objectWellKnownId,
+        objectInternalId,
         ns.rdf('type'),
         ns.example('DataType'),
       ),
     );
 
     const labelLiterals = this.getLabel(object);
-    labelLiterals.forEach(x => quads.push(this.df.quad(objectWellKnownId, ns.rdfs('label'), x)));
+    labelLiterals.forEach(x => quads.push(this.df.quad(objectInternalId, ns.rdfs('label'), x)));
 
     return quads;
   }
 
   private createEnumerationSpecificQuads(
     object: EaElement,
-    objectWellKnownId: RDF.NamedNode,
+    objectInternalId: RDF.NamedNode,
     uriRegistry: UriRegistry,
     model: DataRegistry,
   ): RDF.Quad[] {
@@ -274,7 +274,7 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
 
     quads.push(
       this.df.quad(
-        objectWellKnownId,
+        objectInternalId,
         ns.rdf('type'),
         ns.owl('Class'),
       ),
@@ -282,12 +282,12 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
 
     // FIXME: this should be available through a tag (language-aware)
     const label = this.df.literal(object.name);
-    quads.push(this.df.quad(objectWellKnownId, ns.rdfs('label'), label));
+    quads.push(this.df.quad(objectInternalId, ns.rdfs('label'), label));
 
     const codelist = getTagValue(object, TagNames.ApCodelist, null);
 
     if (codelist) {
-      quads.push(this.df.quad(objectWellKnownId, ns.example('codelist'), this.df.namedNode(codelist)));
+      quads.push(this.df.quad(objectInternalId, ns.example('codelist'), this.df.namedNode(codelist)));
     }
 
     return quads;

--- a/packages/oslo-converter-uml-ea/lib/converterHandlers/PackageConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converterHandlers/PackageConverterHandler.ts
@@ -69,21 +69,21 @@ export class PackageConverterHandler extends ConverterHandler<EaPackage> {
     }
 
     const ontologyUriNamedNode = this.df.namedNode(ontologyUri.toString());
-    const uniqueHttpUri = this.df.namedNode(`${this.config.baseUri}/.well-known/id/${object.osloGuid}`);
+    const packageInternalId = this.df.namedNode(`${this.baseUrnScheme}:${object.osloGuid}`);
 
     quads.push(
       this.df.quad(
-        uniqueHttpUri,
+        packageInternalId,
         ns.rdf('type'),
         ns.example('Package'),
       ),
       this.df.quad(
-        uniqueHttpUri,
+        packageInternalId,
         ns.example('assignedUri'),
         ontologyUriNamedNode,
       ),
       this.df.quad(
-        uniqueHttpUri,
+        packageInternalId,
         ns.example('baseUri'),
         this.df.namedNode(baseUri.toString()),
       ),

--- a/packages/oslo-converter-uml-ea/lib/interfaces/ConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/interfaces/ConverterHandler.ts
@@ -14,6 +14,7 @@ export abstract class ConverterHandler<T extends EaObject> {
   @inject(EaUmlConverterServiceIdentifier.Configuration) public readonly config!: EaUmlConverterConfiguration;
   @inject(EaUmlConverterServiceIdentifier.Logger) public readonly logger!: Logger;
   public readonly df = new DataFactory();
+  public readonly baseUrnScheme: string = 'urn:oslo-toolchain';
 
   /**
    * Creates RDF.Quads for objects with type T in the normalized model and adds them to an RDF.Store


### PR DESCRIPTION
This PR includes the following fixes and updates:
- baseUri parameter is removed because it is not being used anymore. It was used to create the version URI of the document, but now the variable `publicationEnvironment` is used instead.
- Instead of using HTTP URIs for each object in the JSON-LD document, we switched to URNs so that it is clear to readers that these IDs are for internal use only.
- Attributes that have a domain that is an enumeration are now being ignored (filtered out of the array before creating quads)
- Change when assigning URIs to connectors. Only when there is no "uri" tag defined on the connector, a URI is constructed by using other information. Previously, this was not the case.