### PR TITLE
SDTT-108-Migrate-from-logging-EA-guid-to-element-path

### DIFF
--- a/packages/oslo-converter-uml-ea/lib/converterHandlers/AttributeConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converterHandlers/AttributeConverterHandler.ts
@@ -47,7 +47,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
       const attributeClass = model.elements.find(x => x.id === attribute.classId);
 
       if (!attributeClass) {
-        throw new Error(`[AttributeConverterHandler]: Unable to find domain for attribute with EA guid ${attribute.eaGuid}.`);
+        throw new Error(`[AttributeConverterHandler]: Unable to find domain for attribute (${attribute.path}).`);
       }
 
       let attributeBaseUri: URL;


### PR DESCRIPTION
- Updated `AttributeConverterHandler` to log _attribute.path_ instead of _attribute.eaGuid_.