### PR TITLE
Update ElementConverterHandler + OutputHandler + context file

### DIFF
--- a/packages/oslo-converter-uml-ea/lib/converterHandlers/ElementConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converterHandlers/ElementConverterHandler.ts
@@ -254,7 +254,7 @@ export class ElementConverterHandler extends ConverterHandler<EaElement> {
       this.df.quad(
         objectInternalId,
         ns.rdf('type'),
-        ns.example('DataType'),
+        ns.rdfs('Datatype')
       ),
     );
 

--- a/packages/oslo-output-handlers/lib/JsonLdOutputHandler.ts
+++ b/packages/oslo-output-handlers/lib/JsonLdOutputHandler.ts
@@ -22,7 +22,7 @@ export class JsonLdOutputHandler implements IOutputHandler {
     document.packages = packages;
     document.classes = classes;
     document.attributes = attributes;
-    document.dataTypes = dataTypes;
+    document.datatypes = dataTypes;
     document.statements = statements;
 
     (<WriteStream>writeStream).write(JSON.stringify(document, null, 2));
@@ -200,10 +200,7 @@ export class JsonLdOutputHandler implements IOutputHandler {
   }
 
   private async getDataTypes(store: QuadStore): Promise<any> {
-    const datatypeIds = store.findSubjects(
-      ns.rdf('type'),
-      ns.example('DataType')
-    );
+    const datatypeIds = store.findSubjects(ns.rdf('type'), ns.rdfs('Datatype'));
     return datatypeIds.map((subject) => {
       const assignedUri = store.getAssignedUri(subject);
       const definitionQuads = store.getDefinitions(subject);

--- a/packages/oslo-output-handlers/lib/utils/osloContext.ts
+++ b/packages/oslo-output-handlers/lib/utils/osloContext.ts
@@ -101,6 +101,9 @@ export function getOsloContext(): any {
         '@id': 'http://example.org/assignedUri',
         '@type': '@id',
       },
+      Datatype: {
+        '@id': 'rdfs:Datatype',
+      },
     },
   };
 }


### PR DESCRIPTION
- Update `ElementConverterHandler` to push _triples_ with type `rdfs:Datatype` insteads of `example:Datatype`
- Update `JsonldOutputHandler` to set property `datatypes` insteads of `dataTypes` because it was annotated as `datatypes` in the JSON-LD context
- Added `Datatype` to the JSON-LD context with `rdfs:Datatype` as identifier