### PR TITLE
SDTT-112-JsonLdOutputHandler-does-not-add-assignedURI-to-rdf-Statement

### DIFF
--- a/packages/oslo-converter-uml-ea/lib/converterHandlers/AttributeConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converterHandlers/AttributeConverterHandler.ts
@@ -164,7 +164,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
       ),
     );
 
-    quads.push(...this.addRangeRdfStatement(attributeInternalId, rangeUriNamedNode, model, rangeLabel, rangeElement));
+    quads.push(...this.addRangeRdfStatement(attributeInternalId, rangeUriNamedNode, model, uriRegistry, rangeLabel, rangeElement));
 
     const definitionLiterals = this.getDefinition(object);
     definitionLiterals.forEach(x => quads.push(this.df.quad(attributeInternalId, ns.rdfs('comment'), x)));
@@ -232,6 +232,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
     attributeUri: RDF.NamedNode,
     rangeUri: RDF.NamedNode,
     model: DataRegistry,
+    uriRegistry: UriRegistry,
     rangeLabel?: string,
     rangeElement?: EaElement,
   ): RDF.Quad[] {
@@ -255,6 +256,19 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
 
       const usageNoteValues = <RDF.Literal[]>(<any>this.getUsageNote)(rangeElement);
       usageNoteValues.forEach(x => quads.push(this.df.quad(statementBlankNode, ns.vann('usageNote'), x)));
+
+      const assignedUri = uriRegistry.elementIdUriMap.get(rangeElement.id);
+      if(!assignedUri){
+        throw new Error(`[AttributeConverterHandler]: Unable to find the assigned URI for the range (${rangeElement.path}) of attribute.`);
+      }
+
+      quads.push(
+        this.df.quad(
+          statementBlankNode,
+          ns.example('assignedUri'),
+          this.df.namedNode(assignedUri.toString())
+        )
+      )
 
       const skosCodelist = getTagValue(rangeElement, TagNames.ApCodelist, null);
       if (skosCodelist) {

--- a/packages/oslo-output-handlers/lib/JsonLdOutputHandler.ts
+++ b/packages/oslo-output-handlers/lib/JsonLdOutputHandler.ts
@@ -249,6 +249,7 @@ export class JsonLdOutputHandler implements IOutputHandler {
       const statementPredicate = store.findObject(subject, ns.rdf('predicate'));
       const statementObject = store.findObject(subject, ns.rdf('object'));
 
+      const statementAssignedUri = store.findObject(subject, ns.example('assignedUri'));
       const statementLabels = store.findObjects(subject, ns.rdfs('label'));
       const statementDefinitions = store.findObjects(
         subject,
@@ -274,6 +275,9 @@ export class JsonLdOutputHandler implements IOutputHandler {
         object: {
           '@id': statementObject?.value,
         },
+        ...(statementAssignedUri && {
+          assignedUri: statementAssignedUri.value,
+        }),
         ...(statementLabels.length > 0 && {
           label: statementLabels.map((x) => ({
             '@language': (<RDF.Literal>x).language,


### PR DESCRIPTION
- Adding `assignedUri` to `rdf:Statement` in output via `JsonldOutputHandler`
- Adding the assigned URI of a range that is not included in the diagram to the quad store as well.