### PR TITLE
SDTT-111-RdfVocabularyGenerator-only-checks-for-parent-assigned-URI-in-classes-array

### DIFF
--- a/packages/oslo-generator-rdf-vocabulary/lib/RdfVocabularyGenerationService.ts
+++ b/packages/oslo-generator-rdf-vocabulary/lib/RdfVocabularyGenerationService.ts
@@ -115,7 +115,13 @@ export class RdfVocabularyGenerationService implements IService {
 
       const parents = this.store.getParentsOfClass(subject);
       parents.forEach(parent => {
-        const parentAssignedUri = this.store.getAssignedUri(parent);
+        const parentAssignedUri =
+          this.store.getAssignedUri(parent) ||
+          this.store.getAssignedUriViaStatements(
+            subject,
+            ns.rdfs('subClassOf'),
+            parent
+          );;
 
         if (!parentAssignedUri) {
           throw new Error(`Unable to find the assigned URI for parent ${parent.value} of class ${subject.value}.`);


### PR DESCRIPTION
- When extracting the assigned URI of the parent of a class, the `rdf:Statements` are now also taken into account.