### PR TITLE
Fix connector normalisation function

### DIFF
--- a/packages/oslo-converter-uml-ea/lib/converter-handlers/ConnectorConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converter-handlers/ConnectorConverterHandler.ts
@@ -46,14 +46,9 @@ export class ConnectorConverterHandler extends ConverterHandler<NormalizedConnec
   }
 
   public async normalize(model: DataRegistry): Promise<DataRegistry> {
-    const tasks: Promise<NormalizedConnector[]>[] = [];
-    model.connectors
+    const tasks: Promise<NormalizedConnector[]>[] = model.connectors
       .filter(x => model.targetDiagram.connectorsIds.includes(x.id))
-      .forEach(connector => {
-        tasks.push(
-          this.connectorNormalisationService.normalise(connector, model),
-        );
-      });
+      .map(connector => this.connectorNormalisationService.normalise(connector, model));
 
     model.normalizedConnectors = await Promise.all(tasks).then(x => x.flat());
 

--- a/packages/oslo-converter-uml-ea/lib/converter-handlers/ConnectorConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converter-handlers/ConnectorConverterHandler.ts
@@ -47,11 +47,13 @@ export class ConnectorConverterHandler extends ConverterHandler<NormalizedConnec
 
   public async normalize(model: DataRegistry): Promise<DataRegistry> {
     const tasks: Promise<NormalizedConnector[]>[] = [];
-    model.connectors.forEach(connector => {
-      tasks.push(
-        this.connectorNormalisationService.normalise(connector, model),
-      );
-    });
+    model.connectors
+      .filter(x => model.targetDiagram.connectorsIds.includes(x.id))
+      .forEach(connector => {
+        tasks.push(
+          this.connectorNormalisationService.normalise(connector, model),
+        );
+      });
 
     model.normalizedConnectors = await Promise.all(tasks).then(x => x.flat());
 


### PR DESCRIPTION
Only process connectors that appear on the target diagram. Connectors that do not appear on the target diagram are not processed. Mistakes in these connectors are not discovered by the converter.