### PR TITLE
Fix addScope function

### DIFF
--- a/packages/oslo-converter-uml-ea/lib/interfaces/ConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/interfaces/ConverterHandler.ts
@@ -190,14 +190,15 @@ export abstract class ConverterHandler<T extends EaObject> {
         `[ConverterHandler]: Unable to find the URI for object with path ${object.path}. Setting scope to "Undefined".`,
       );
       scope = Scope.Undefined;
+      return;
     }
 
-    if (uri?.toString().startsWith(packageBaseUri)) {
-      scope = Scope.InPackage;
-    }
-
-    if (uri?.toString().startsWith(this.config.publicationEnvironment)) {
+    if (uri.toString().startsWith(this.config.publicationEnvironment)) {
       scope = Scope.InPublicationEnvironment;
+    }
+
+    if (uri.toString().startsWith(packageBaseUri)) {
+      scope = Scope.InPackage;
     }
 
     quads.push(


### PR DESCRIPTION
To determine the scope, first the `packageBaseUri` was checked and then the `this.config.publicationEnvironment` variable was is set by CLI. However, the first one is more specific than the latter, meaning that the "if"-statement with the latter will always be true.

Therefore, we switch both if-statements.