### PR TITLE
Add error message for empty localName

### DIFF
--- a/packages/oslo-converter-uml-ea/lib/converter-handlers/AttributeConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converter-handlers/AttributeConverterHandler.ts
@@ -84,6 +84,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
       const externalUri: string = getTagValue(attribute, TagNames.ExternalUri, null);
       if (externalUri) {
         uriRegistry.attributeIdUriMap.set(attribute.id, new URL(externalUri));
+        return;
       }
 
       let attributeBaseURI: string | undefined;
@@ -137,6 +138,10 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
         TagNames.LocalName,
         attribute.name,
       );
+
+      if(!localName){
+        throw new Error(`[AttributeConverterHandler]: Unable to determine local name for attribute (${attribute.path}). If you used a "name" tag, did you set it correctly?`)
+      }
       localName = toCamelCase(localName);
 
       const attributeURI: URL = new URL(`${attributeBaseURI}${localName}`);


### PR DESCRIPTION
- Added return statement if there is a `uri` tag set. There is no need to go further in that case.
- Added extra if-statement with error message if `localName` contains a `null` value or is `undefined`. This case can happen if the OSLO editor adds a `name` tag to the diagram, but does not provide a value for it.