### PR TITLE
Update to latest functions of QuadStore

### DIFF
--- a/packages/oslo-core/index.ts
+++ b/packages/oslo-core/index.ts
@@ -20,3 +20,4 @@ export * from '@oslo-core/logging/LogUtil';
 export * from '@oslo-core/logging/LoggerFactory';
 export * from '@oslo-core/logging/VoidLoggerFactory';
 export * from '@oslo-core/logging/WinstonLoggerFactory';
+export * from '@oslo-core/utils/storeUtils';

--- a/packages/oslo-core/lib/utils/namespaces.ts
+++ b/packages/oslo-core/lib/utils/namespaces.ts
@@ -2,7 +2,6 @@ import { DataFactory } from 'rdf-data-factory';
 
 const factory = new DataFactory();
 
-// TODO: remove example.org from prefixes
 enum Prefixes {
   adms = 'http://www.w3.org/ns/adms#',
   dcat = 'http://www.w3.org/ns/dcat#',

--- a/packages/oslo-core/lib/utils/storeUtils.ts
+++ b/packages/oslo-core/lib/utils/storeUtils.ts
@@ -1,0 +1,116 @@
+import type * as RDF from '@rdfjs/types';
+import type { QuadStore } from '@oslo-core/store/QuadStore';
+import { ns } from '@oslo-core/utils/namespaces';
+
+export function getApplicationProfileLabel(
+    subject: RDF.Term,
+    store: QuadStore,
+    language: string | null = null,
+): RDF.Literal | undefined {
+    const labels = store.getLabels(subject);
+
+    if (labels.some(x => x.predicate.equals(ns.oslo('apLabel')))) {
+        return <RDF.Literal>labels
+            .find(x => x.predicate.equals(ns.oslo('apLabel')) &&
+                (<RDF.Literal>x.object).language === (language || ''))?.object
+    }
+
+    if (labels.some(x => x.predicate.equals(ns.oslo('vocLabel')))) {
+        return <RDF.Literal>
+            labels.find(x => x.predicate.equals(ns.oslo('vocLabel')) &&
+                (<RDF.Literal>x.object).language === (language || ''))?.object;
+    }
+    return <RDF.Literal | undefined>labels.find(x => x.predicate.equals(ns.oslo('diagramLabel')))?.object;
+}
+
+export function getVocabularyLabel(
+    subject: RDF.Term,
+    store: QuadStore,
+    language: string | null = null,
+): RDF.Literal | undefined {
+    const labels = store.getLabels(subject);
+
+    if (labels.some(x => x.predicate.equals(ns.oslo('vocLabel')))) {
+        return <RDF.Literal>labels
+            .find(x => x.predicate.equals(ns.oslo('vocLabel')) &&
+                (<RDF.Literal>x.object).language === (language || ''))?.object;
+    }
+    return <RDF.Literal | undefined>labels.find(x => x.predicate.equals(ns.oslo('diagramLabel')))?.object;
+}
+
+export function getApplicationProfileDefinition(
+    subject: RDF.Term,
+    store: QuadStore,
+    language: string | null = null,
+): RDF.Literal | undefined {
+    const definitions = store.getDefinitions(subject);
+
+    if (definitions.some(x => x.predicate.equals(ns.oslo('apDefinition')))) {
+        return <RDF.Literal>definitions
+            .find(x => x.predicate.equals(ns.oslo('apDefinition')) &&
+                (<RDF.Literal>x.object).language === (language || ''))?.object;
+    }
+
+    if (definitions.some(x => x.predicate.equals(ns.oslo('vocDefinition')))) {
+        return <RDF.Literal>definitions
+            .find(x => x.predicate.equals(ns.oslo('vocDefinition')) &&
+                (<RDF.Literal>x.object).language === (language || ''))?.object;
+    }
+
+    return undefined;
+}
+
+export function getVocabularyDefinition(
+    subject: RDF.Term,
+    store: QuadStore,
+    language: string | null = null,
+): RDF.Literal | undefined {
+    const definitions = store.getDefinitions(subject);
+
+    if (definitions.some(x => x.predicate.equals(ns.oslo('vocDefinition')))) {
+        return <RDF.Literal>definitions
+            .find(x => x.predicate.equals(ns.oslo('vocDefinition')) &&
+                (<RDF.Literal>x.object).language === (language || ''))?.object;
+    }
+
+    return undefined;
+}
+
+export function getApplicationProfileUsageNote(
+    subject: RDF.Term,
+    store: QuadStore,
+    language: string | null = null,
+): RDF.Literal | undefined {
+    const usageNotes = store.getUsageNotes(subject);
+
+    if (usageNotes.some(x => x.predicate.equals(ns.oslo('apUsageNote')))) {
+        return <RDF.Literal>usageNotes
+            .find(x => x.predicate.equals(ns.oslo('apUsageNote')) &&
+                (<RDF.Literal>x.object).language === (language || ''))?.object;
+    }
+
+    if (usageNotes.some(x => x.predicate.equals(ns.oslo('vocUsageNote')))) {
+        return <RDF.Literal>usageNotes
+            .find(x => x.predicate.equals(ns.oslo('vocUsageNote')) &&
+                (<RDF.Literal>x.object).language === (language || ''))?.object;
+    }
+
+    return undefined;
+}
+
+export function getVocabularyUsageNote(
+    subject: RDF.Term,
+    store: QuadStore,
+    language: string | null = null,
+): RDF.Literal | undefined {
+    const usageNotes = store.getUsageNotes(subject);
+
+    if (usageNotes.some(x => x.predicate.equals(ns.oslo('vocUsageNote')))) {
+        return <RDF.Literal>usageNotes
+            .find(x => x.predicate.equals(ns.oslo('vocUsageNote')) &&
+                (<RDF.Literal>x.object).language === (language || ''))?.object;
+    }
+
+    return undefined;
+}
+

--- a/packages/oslo-generator-jsonld-context/lib/JsonldContextGenerationService.ts
+++ b/packages/oslo-generator-jsonld-context/lib/JsonldContextGenerationService.ts
@@ -6,7 +6,8 @@ import {
   Logger,
   ns,
   ServiceIdentifier,
-  QuadStore
+  QuadStore,
+  getApplicationProfileLabel
 } from '@oslo-flanders/core';
 
 import type * as RDF from '@rdfjs/types';
@@ -79,8 +80,7 @@ export class JsonldContextGenerationService implements IService {
     const labelUriMap: Map<string, RDF.NamedNode[]> = new Map();
 
     uris.forEach(uri => {
-      const label = this.store.getApLabel(uri, this.configuration.language) || this.store.getApLabel(uri) ||
-        this.store.getVocLabel(uri, this.configuration.language) || this.store.getVocLabel(uri) || this.store.getDiagramLabel(uri);
+      const label = getApplicationProfileLabel(uri, this.store, this.configuration.language);
 
       if (!label) {
         return;
@@ -109,8 +109,7 @@ export class JsonldContextGenerationService implements IService {
     const duplicates = this.identifyDuplicateLabels(classSubjects);
 
     classSubjects.forEach(subject => {
-      const label = this.store.getApLabel(subject, this.configuration.language) || this.store.getApLabel(subject) ||
-        this.store.getVocLabel(subject, this.configuration.language) || this.store.getVocLabel(subject) || this.store.getDiagramLabel(subject);
+      const label = getApplicationProfileLabel(subject, this.store, this.configuration.language);
 
       if (!label) {
         this.logger.warn(`No label found for class ${subject.value} in language ${this.configuration.language}.`);
@@ -152,8 +151,7 @@ export class JsonldContextGenerationService implements IService {
         return;
       }
 
-      const label = this.store.getApLabel(subject, this.configuration.language) || this.store.getApLabel(subject) ||
-        this.store.getVocLabel(subject, this.configuration.language) || this.store.getVocLabel(subject) || this.store.getDiagramLabel(subject);
+      const label = getApplicationProfileLabel(subject, this.store, this.configuration.language);
 
       if (!label) {
         this.logger.error(`No label found for attribute ${subject.value} in language "${this.configuration.language}" or without language tag.`);
@@ -183,8 +181,7 @@ export class JsonldContextGenerationService implements IService {
           return;
         }
 
-        const domainLabel = this.store.getApLabel(domain, this.configuration.language) || this.store.getApLabel(domain) ||
-          this.store.getVocLabel(domain, this.configuration.language) || this.store.getVocLabel(domain) || this.store.getDiagramLabel(domain);
+        const domainLabel = getApplicationProfileLabel(domain, this.store, this.configuration.language);
 
         if (!domainLabel) {
           this.logger.error(`No label found for domain ${domain.value} of attribute ${subject.value}.`);

--- a/packages/oslo-generator-rdf-vocabulary/lib/RdfVocabularyGenerationService.ts
+++ b/packages/oslo-generator-rdf-vocabulary/lib/RdfVocabularyGenerationService.ts
@@ -1,5 +1,5 @@
 /* eslint-disable eslint-comments/disable-enable-pair */
- 
+
 import { createWriteStream } from 'fs';
 import type { IService } from '@oslo-flanders/core';
 import {
@@ -102,7 +102,7 @@ export class RdfVocabularyGenerationService implements IService {
         ),
       );
 
-      const definition = this.store.getDefinition(subject, this.configuration.language);
+      const definition = this.store.getVocDefinition(subject, this.configuration.language) || this.store.getVocDefinition(subject);
       if (!definition) {
         this.logger.error(`Unable to find the definition for class ${subject.value}.`);
       } else {
@@ -117,13 +117,7 @@ export class RdfVocabularyGenerationService implements IService {
 
       const parents = this.store.getParentsOfClass(subject);
       parents.forEach(parent => {
-        const parentAssignedUri =
-          this.store.getAssignedUri(parent) ||
-          this.store.getAssignedUriViaStatements(
-            subject,
-            ns.rdfs('subClassOf'),
-            parent,
-          );
+        const parentAssignedUri = this.store.getAssignedUri(parent);
 
         if (!parentAssignedUri) {
           throw new Error(`Unable to find the assigned URI for parent ${parent.value} of class ${subject.value}.`);
@@ -138,7 +132,7 @@ export class RdfVocabularyGenerationService implements IService {
         );
       });
 
-      const usageNote = this.store.getUsageNote(subject, this.configuration.language);
+      const usageNote = this.store.getVocUsageNote(subject, this.configuration.language) || this.store.getVocUsageNote(subject);
       if (usageNote) {
         quads.push(
           this.dataFactory.quad(
@@ -208,18 +202,7 @@ export class RdfVocabularyGenerationService implements IService {
         return;
       }
 
-      let rangeAssignedUri = this.store.getAssignedUri(rangeWellKnownId);
-      if (!rangeAssignedUri) {
-        const targetId = this.store.getTargetStatementId(
-          id,
-          ns.rdfs('range'),
-          rangeWellKnownId,
-        );
-
-        if (targetId) {
-          rangeAssignedUri = this.store.getAssignedUri(targetId);
-        }
-      }
+      const rangeAssignedUri = this.store.getAssignedUri(rangeWellKnownId);
 
       if (!rangeAssignedUri) {
         this.logger.error(`Unable to find assigned URI for range of property ${id.value}.`);
@@ -244,7 +227,7 @@ export class RdfVocabularyGenerationService implements IService {
         );
       }
 
-      const definition = this.store.getDefinition(id, this.configuration.language);
+      const definition = this.store.getVocDefinition(id, this.configuration.language) || this.store.getVocDefinition(id);
       if (!definition) {
         this.logger.error(`Unable to find the definition for property ${id.value}.`);
       } else {
@@ -257,7 +240,7 @@ export class RdfVocabularyGenerationService implements IService {
         );
       }
 
-      const usageNote = this.store.getUsageNote(id, this.configuration.language);
+      const usageNote = this.store.getVocUsageNote(id, this.configuration.language) || this.store.getVocDefinition(id);
       if (usageNote) {
         quads.push(
           this.dataFactory.quad(

--- a/packages/oslo-generator-rdf-vocabulary/lib/RdfVocabularyGenerationService.ts
+++ b/packages/oslo-generator-rdf-vocabulary/lib/RdfVocabularyGenerationService.ts
@@ -7,6 +7,8 @@ import {
   ns,
   Logger,
   ServiceIdentifier,
+  getVocabularyDefinition,
+  getVocabularyUsageNote,
 } from '@oslo-flanders/core';
 
 import type * as RDF from '@rdfjs/types';
@@ -102,7 +104,7 @@ export class RdfVocabularyGenerationService implements IService {
         ),
       );
 
-      const definition = this.store.getVocDefinition(subject, this.configuration.language) || this.store.getVocDefinition(subject);
+      const definition = getVocabularyDefinition(subject, this.store, this.configuration.language);
       if (!definition) {
         this.logger.error(`Unable to find the definition for class ${subject.value}.`);
       } else {
@@ -132,7 +134,7 @@ export class RdfVocabularyGenerationService implements IService {
         );
       });
 
-      const usageNote = this.store.getVocUsageNote(subject, this.configuration.language) || this.store.getVocUsageNote(subject);
+      const usageNote = getVocabularyUsageNote(subject, this.store, this.configuration.language);
       if (usageNote) {
         quads.push(
           this.dataFactory.quad(
@@ -227,7 +229,7 @@ export class RdfVocabularyGenerationService implements IService {
         );
       }
 
-      const definition = this.store.getVocDefinition(id, this.configuration.language) || this.store.getVocDefinition(id);
+      const definition = getVocabularyDefinition(id, this.store, this.configuration.language)
       if (!definition) {
         this.logger.error(`Unable to find the definition for property ${id.value}.`);
       } else {
@@ -240,7 +242,7 @@ export class RdfVocabularyGenerationService implements IService {
         );
       }
 
-      const usageNote = this.store.getVocUsageNote(id, this.configuration.language) || this.store.getVocDefinition(id);
+      const usageNote = getVocabularyUsageNote(id, this.store, this.configuration.language);
       if (usageNote) {
         quads.push(
           this.dataFactory.quad(

--- a/packages/oslo-generator-respec-html/lib/HtmlRespecGenerationService.ts
+++ b/packages/oslo-generator-respec-html/lib/HtmlRespecGenerationService.ts
@@ -1,8 +1,7 @@
 import { writeFile, mkdir } from 'fs/promises';
 import { resolve, dirname } from 'path';
 import type { IService } from '@oslo-flanders/core';
-import { ns, Logger, QuadStore, ServiceIdentifier } from '@oslo-flanders/core';
-
+import { ns, Logger, QuadStore, ServiceIdentifier, getApplicationProfileLabel, getVocabularyLabel, getApplicationProfileDefinition, getVocabularyDefinition, getApplicationProfileUsageNote, getVocabularyUsageNote } from '@oslo-flanders/core';
 import type * as RDF from '@rdfjs/types';
 import { inject, injectable } from 'inversify';
 import * as nj from 'nunjucks';
@@ -104,23 +103,14 @@ export class HtmlRespecGenerationService implements IService {
         const assignedUri = this.store.getAssignedUri(subjectId);
         const parents = this.store.getParentsOfClass(subjectId);
 
-        let label;
-        let definition;
-        let usageNote;
-        if (this.configuration.specificationType === SpecificationType.ApplicationProfile) {
-          label = this.store.getApLabel(subjectId, this.configuration.language) || this.store.getApLabel(subjectId) ||
-            this.store.getVocLabel(subjectId, this.configuration.language) || this.store.getVocLabel(subjectId) || this.store.getDiagramLabel(subjectId);
+        const label = this.configuration.specificationType === SpecificationType.ApplicationProfile ?
+          getApplicationProfileLabel(subjectId, this.store, this.configuration.language) : getVocabularyLabel(subjectId, this.store, this.configuration.language);
 
-          definition = this.store.getApDefinition(subjectId, this.configuration.language) || this.store.getApDefinition(subjectId) ||
-            this.store.getVocDefinition(subjectId, this.configuration.language) || this.store.getVocDefinition(subjectId);
+        const definition = this.configuration.specificationType === SpecificationType.ApplicationProfile ?
+          getApplicationProfileDefinition(subjectId, this.store, this.configuration.language) : getVocabularyDefinition(subjectId, this.store, this.configuration.language);
 
-          usageNote = this.store.getApUsageNote(subjectId, this.configuration.language) || this.store.getApUsageNote(subjectId) ||
-            this.store.getVocUsageNote(subjectId, this.configuration.language) || this.store.getVocUsageNote(subjectId);
-        } else {
-          label = this.store.getVocLabel(subjectId, this.configuration.language) || this.store.getVocLabel(subjectId) || this.store.getDiagramLabel(subjectId);
-          definition = this.store.getVocDefinition(subjectId, this.configuration.language) || this.store.getVocDefinition(subjectId)
-          usageNote = this.store.getVocUsageNote(subjectId, this.configuration.language) || this.store.getVocUsageNote(subjectId)
-        }
+        const usageNote = this.configuration.specificationType === SpecificationType.ApplicationProfile ?
+          getApplicationProfileUsageNote(subjectId, this.store, this.configuration.language) : getVocabularyUsageNote(subjectId, this.store, this.configuration.language)
 
         const parentAssignedUris: string[] = [];
         parents.forEach(parent => {
@@ -155,23 +145,14 @@ export class HtmlRespecGenerationService implements IService {
         const minCount = this.store.getMinCardinality(subjectId);
         const maxCount = this.store.getMaxCardinality(subjectId);
 
-        let label;
-        let definition;
-        let usageNote;
-        if (this.configuration.specificationType === SpecificationType.ApplicationProfile) {
-          label = this.store.getApLabel(subjectId, this.configuration.language) || this.store.getApLabel(subjectId) ||
-            this.store.getVocLabel(subjectId, this.configuration.language) || this.store.getVocLabel(subjectId) || this.store.getDiagramLabel(subjectId);
+        const label = this.configuration.specificationType === SpecificationType.ApplicationProfile ?
+          getApplicationProfileLabel(subjectId, this.store, this.configuration.language) : getVocabularyLabel(subjectId, this.store, this.configuration.language);
 
-          definition = this.store.getApDefinition(subjectId, this.configuration.language) || this.store.getApDefinition(subjectId) ||
-            this.store.getVocDefinition(subjectId, this.configuration.language) || this.store.getVocDefinition(subjectId);
+        const definition = this.configuration.specificationType === SpecificationType.ApplicationProfile ?
+          getApplicationProfileDefinition(subjectId, this.store, this.configuration.language) : getVocabularyDefinition(subjectId, this.store, this.configuration.language);
 
-          usageNote = this.store.getApUsageNote(subjectId, this.configuration.language) || this.store.getApUsageNote(subjectId) ||
-            this.store.getVocUsageNote(subjectId, this.configuration.language) || this.store.getVocUsageNote(subjectId);
-        } else {
-          label = this.store.getVocLabel(subjectId, this.configuration.language) || this.store.getVocLabel(subjectId) || this.store.getDiagramLabel(subjectId);
-          definition = this.store.getVocDefinition(subjectId, this.configuration.language) || this.store.getVocDefinition(subjectId)
-          usageNote = this.store.getVocUsageNote(subjectId, this.configuration.language) || this.store.getVocUsageNote(subjectId)
-        }
+        const usageNote = this.configuration.specificationType === SpecificationType.ApplicationProfile ?
+          getApplicationProfileUsageNote(subjectId, this.store, this.configuration.language) : getVocabularyUsageNote(subjectId, this.store, this.configuration.language)
 
         const domain = this.store.getDomain(subjectId);
         if (!domain) {


### PR DESCRIPTION
The three generators `JsonLdContextGenerator`, `RdfVocabularyGenerator` and `HtmlReSpecGenerator` were using the old function of the `QuadStore`, causing build errors. They now have been migrated to use the latest functions.