### PR TITLE
Bumped minimal Node version for integration test CI to `18.x` and added Node `20.x` as second version

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -13,9 +13,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version:
-          - 14.x
-          - 16.x
           - 18.x
+          - 20.x
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
Deleted Node version `14.x` and `16.x` from integration workflow since these Node versions are no longer maintained and don't run on Github Actions!