### PR TITLE
Hard couple attribute type to an element object

### DIFF
--- a/packages/oslo-converter-uml-ea/lib/converter-handlers/AttributeConverterHandler.ts
+++ b/packages/oslo-converter-uml-ea/lib/converter-handlers/AttributeConverterHandler.ts
@@ -236,9 +236,8 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
       const rangeLabel: string = object.type;
       attributeType = PropertyType.Property;
 
-      const rangeElement: EaElement | undefined = model.elements.find(x => x.name === rangeLabel);
-
-      if (rangeElement) {
+      if (object.rangeClassId && model.elements.some(x => x.id === object.rangeClassId)) {
+        const rangeElement: EaElement = model.elements.find(x => x.id === object.rangeClassId)!
         const rangeIsLiteral: string = getTagValue(
           rangeElement,
           TagNames.IsLiteral,
@@ -282,6 +281,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
         `[AttributeConverterHandler]: Unable to get the URI for the range of attribute (${object.path}).`,
       );
     }
+
 
     quads.push(
       this.df.quad(
@@ -404,7 +404,7 @@ export class AttributeConverterHandler extends ConverterHandler<EaAttribute> {
         `[AttributeConverterHandler]: Unable to find the URI of package where target diagram (${dataRegistry.targetDiagram.path}) is placed.`,
       );
     }
-    
+
     this.addScope(
       <any>rangeElement,
       rangeInternalId,

--- a/packages/oslo-extractor-uml-ea/lib/types/EaAttribute.ts
+++ b/packages/oslo-extractor-uml-ea/lib/types/EaAttribute.ts
@@ -9,6 +9,7 @@ export class EaAttribute extends EaObject {
   public readonly type: string;
   public readonly lowerBound: string;
   public readonly upperBound: string;
+  public readonly rangeClassId: number | undefined;
 
   public constructor(
     id: number,
@@ -18,6 +19,7 @@ export class EaAttribute extends EaObject {
     type: string,
     lowerBound: string,
     upperBound: string,
+    rangeClassId?: number,
   ) {
     super(id, name, guid);
 
@@ -25,6 +27,7 @@ export class EaAttribute extends EaObject {
     this.type = type;
     this.lowerBound = lowerBound;
     this.upperBound = upperBound;
+    this.rangeClassId = rangeClassId;
 
     this.osloGuid = uniqueId(guid, name, id);
   }

--- a/packages/oslo-extractor-uml-ea/lib/utils/loadAttributes.ts
+++ b/packages/oslo-extractor-uml-ea/lib/utils/loadAttributes.ts
@@ -20,6 +20,7 @@ export function loadAttributes(mdb: MDBReader, model: DataRegistry): DataRegistr
         <string>attribute.Type,
         <string>attribute.LowerBound,
         <string>attribute.UpperBound,
+        Number.parseInt(attribute.Classifier, 10) || undefined,
       ));
     }
 


### PR DESCRIPTION
Fixes the problem where multiple classes with the same name appear and we match the type of the attribute to the wrong class object.