### PR TITLE
Update codelist logic in webuniversum generator

### DIFF
--- a/packages/oslo-core/lib/utils/storeUtils.ts
+++ b/packages/oslo-core/lib/utils/storeUtils.ts
@@ -127,11 +127,3 @@ export function getMaxCount(
 ): string | undefined {
     return store.findObject(subject, ns.shacl('maxCount'))?.value;
 }
-
-export function getCodelist(
-    subject: RDF.Term,
-    store: QuadStore,
-): string | undefined {
-    return store.findObject(subject, ns.oslo('codelist'))?.value;
-}
-

--- a/packages/oslo-generator-json-webuniversum/lib/JsonWebuniversumGenerationService.ts
+++ b/packages/oslo-generator-json-webuniversum/lib/JsonWebuniversumGenerationService.ts
@@ -12,7 +12,6 @@ import {
   ns,
   getMinCount,
   getMaxCount,
-  getCodelist
 } from "@oslo-flanders/core";
 import { inject, injectable } from "inversify";
 import { JsonWebuniversumGenerationServiceConfiguration } from "@oslo-generator-json-webuniversum/config/JsonWebuniversumGenerationServiceConfiguration";
@@ -169,7 +168,15 @@ export class JsonWebuniversumGenerationService implements IService {
 
     getMinCount(subject, this.store) && (propertyObject.minCount = getMinCount(subject, this.store));
     getMaxCount(subject, this.store) && (propertyObject.maxCount = getMaxCount(subject, this.store));
-    getCodelist(subject, this.store) && (propertyObject.codelist = getCodelist(subject, this.store));
+
+    let codelist = this.store.getCodelist(subject);
+    if (!codelist && rangeAssignedURI.equals(ns.skos('Concept'))) {
+      codelist = this.store.getCodelist(range);
+    }
+
+    if (codelist) {
+      propertyObject.codelist = codelist.value;
+    }
 
     return propertyObject;
   }

--- a/packages/oslo-generator-json-webuniversum/test/JsonWebuniversumGenerationService.unit.test.ts
+++ b/packages/oslo-generator-json-webuniversum/test/JsonWebuniversumGenerationService.unit.test.ts
@@ -19,6 +19,7 @@ import {
 	classWithPropertyWithoutRange,
 	classWithPropertyWithoutRangeAssignedURI,
 	classWithoutAssignedURI,
+	dataWithRangeCodelist,
 	dataWithoutPackage,
 	dataWithoutPackageBaseURI,
 	jsonldClass,
@@ -206,4 +207,16 @@ describe('JsonWebuniversumGenerationServiceConfiguration', () => {
 		expect(() => (<any>service).createParentObject(df.namedNode('http://example.org/.well-known/id/class/1')))
 			.toThrow(new Error(`Unable to find the assigned URI for class http://example.org/.well-known/id/class/1 which acts as a parent.`))
 	});
+
+	it('should check for a codelist by the range if the range is a skos:Concept', async () => {
+		store.addQuads(await parseJsonld(dataWithRangeCodelist));
+		const propertyObject = {};
+		(<any>service).addPropertySpecificInformation(
+			df.namedNode('http://example.org/.well-known/id/property/1'),
+			propertyObject,
+			df.namedNode('http://example.org/.well-known/id/class/1'),
+		);
+
+		expect(propertyObject).toHaveProperty('codelist', 'http://example.org/codelist/1');
+	})
 });

--- a/packages/oslo-generator-json-webuniversum/test/data/mockData.ts
+++ b/packages/oslo-generator-json-webuniversum/test/data/mockData.ts
@@ -295,3 +295,44 @@ export const classWithParentWithoutAssignedURI = [
         '@type': 'http://www.w3.org/2002/07/owl#Class',
     },
 ]
+
+export const dataWithRangeCodelist = [
+    {
+        '@id': 'http://example.org/.well-known/id/property/1',
+        'https://implementatie.data.vlaanderen.be/ns/oslo-toolchain#assignedURI': {
+            '@id': 'http://example.org/id/property/1',
+        },
+        '@type': 'http://www.w3.org/2002/07/owl#DatatypeProperty',
+        'https://implementatie.data.vlaanderen.be/ns/oslo-toolchain#apLabel': [
+            {
+                '@language': 'en',
+                '@value': 'TestProperty',
+            },
+        ],
+        'http://www.w3.org/2000/01/rdf-schema#domain': [
+            {
+                '@id': 'http://example.org/.well-known/id/class/1',
+            },
+        ],
+        'http://www.w3.org/2000/01/rdf-schema#range': {
+            '@id': 'http://example.org/.well-known/id/class/1',
+        },
+        'http://w3.org/ns/shacl#maxCount': '*',
+    },
+    {
+        '@id': 'http://example.org/.well-known/id/class/1',
+        'https://implementatie.data.vlaanderen.be/ns/oslo-toolchain#assignedURI': {
+            '@id': 'http://www.w3.org/2004/02/skos/core#Concept',
+        },
+        '@type': 'http://www.w3.org/2002/07/owl#Class',
+        'https://implementatie.data.vlaanderen.be/ns/oslo-toolchain#apLabel': [
+            {
+                '@language': 'en',
+                '@value': 'TestClass',
+            },
+        ],
+        'https://implementatie.data.vlaanderen.be/ns/oslo-toolchain#codelist': {
+            '@id': 'http://example.org/codelist/1',
+        },
+    },
+]


### PR DESCRIPTION
We always check for a codelist on the property. If there is none, and the URI of the range is skos:Concept, then we check for a codelist there.