### PR TITLE
SDTT-353-subklasse-van-property-in-de-gegenereerde-HTML-linkt-niet-correct-naar-een-anchor-in-de-html-zelf

### DIFF
--- a/packages/oslo-generator-html/lib/templates/ap2.j2
+++ b/packages/oslo-generator-html/lib/templates/ap2.j2
@@ -345,7 +345,7 @@
                                              </dt>
                                              <dd>
                                                 {%- for parent in entity['parents'] %}
-                                                   <a href="{{ parent.id }}">
+                                                   <a href="#{{ parent.applicationProfileLabel[language] | generateAnchorTag() }}">
                                                       {{ parent.applicationProfileLabel[language] }}</a>
                                                    {% if not loop.last %},
                                                    {% endif %}
@@ -474,7 +474,7 @@
                                              <dt>Subklasse van</dt>
                                              <dd>
                                                 {%- for parent in dataType['parents'] %}
-                                                   <a href="{{ parent.id }}">
+                                                   <a href="#{{ parent.applicationProfileLabel[language] | generateAnchorTag() }}">
                                                       {{ parent.applicationProfileLabel[language] }}</a>
                                                    {% if not loop.last %},
                                                    {% endif %}

--- a/packages/oslo-generator-html/package.json
+++ b/packages/oslo-generator-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/html-generator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generates an HTML file using an OSLO webuniversum config",
   "author": "Digitaal Vlaanderen <https://data.vlaanderen.be/id/organisatie/OVO002949>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-generator-html#readme",


### PR DESCRIPTION
[Let subclassOf link to an internal anchor tag on the html instead of the actual URI]