### PR TITLE
Throw a warning for the `ParentURI` if it can't be resolved but it's external. Throw an `Error` if it's an internal URN and can't be resolved

### DIFF
--- a/packages/oslo-generator-json-webuniversum/lib/utils/utils.ts
+++ b/packages/oslo-generator-json-webuniversum/lib/utils/utils.ts
@@ -52,3 +52,12 @@ export const filterWebuniversumObjects = (
   classes.filter((webuniversumObject: WebuniversumObject) =>
     filters.every((filter) => filter(webuniversumObject)),
   );
+
+/**
+ * Determines whether a URI is external based on its format
+ * @param uri The URI to check
+ * @returns Boolean indicating if the URI is external (true) or internal (false)
+ */
+export const isExternalUri = (uri: string): boolean =>
+  // URIs starting with "urn:" are considered internal
+  !uri.startsWith('urn:');

--- a/packages/oslo-generator-json-webuniversum/package.json
+++ b/packages/oslo-generator-json-webuniversum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/json-webuniversum-generator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Generates a JSON file which is used to generate an HTML template using Webuniversum 3",
   "author": "Dwight Van Lancker <dwight.vanlancker@vlaanderen.be>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-generator-json-webuniversum#readme",

--- a/packages/oslo-generator-json-webuniversum/test/JsonWebuniversumGenerationService.unit.test.ts
+++ b/packages/oslo-generator-json-webuniversum/test/JsonWebuniversumGenerationService.unit.test.ts
@@ -9,8 +9,9 @@ import { QuadStore, VoidLogger } from '@oslo-flanders/core';
 import type * as RDF from '@rdfjs/types';
 import { DataFactory } from 'rdf-data-factory';
 import rdfParser from 'rdf-parse';
-import type { JsonWebuniversumGenerationServiceConfiguration,
-} from '../lib/config/JsonWebuniversumGenerationServiceConfiguration';
+import type { 
+  JsonWebuniversumGenerationServiceConfiguration,
+ } from '../lib/config/JsonWebuniversumGenerationServiceConfiguration';
 import { JsonWebuniversumGenerationService } from '../lib/JsonWebuniversumGenerationService';
 import {
   classWithParent,
@@ -242,16 +243,37 @@ describe('JsonWebuniversumGenerationServiceConfiguration', () => {
     });
   });
 
-  it('should throw an error when the assigned URI of a parent can not be found', async () => {
+  it('should log a warning when the assigned URI of a parent cannot be found for an external URI', async () => {
     store.addQuads(await parseJsonld(classWithParentWithoutAssignedURI));
 
-    expect(() =>
-      (<any>service).createParentObject(
-        df.namedNode('http://example.org/.well-known/id/class/1'),
-      ),
-    ).toThrow(
+    const warnSpy = jest.spyOn(logger, 'warn');
+
+    // This should now not throw an error
+    const result = (<any>service).createParentObject(
+      df.namedNode('http://example.org/.well-known/id/class/1'),
+    );
+
+    // Check that a warning was logged with the expected message
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Unable to find the assigned URI for external class http://example.org/.well-known/id/class/1 which acts as a parent. Using original URI as fallback.`,
+    );
+
+    // Check that the method returns an object with just the ID
+    expect(result).toEqual({
+      id: 'http://example.org/.well-known/id/class/1',
+    });
+  });
+
+  it('should still throw an error when the assigned URI of a parent cannot be found for an internal URI', async () => {
+    store.addQuads(await parseJsonld(classWithParentWithoutAssignedURI));
+
+    // Create an internal URN
+    const internalUri = df.namedNode('urn:test:internal-class-id');
+
+    // This should throw an error
+    expect(() => (<any>service).createParentObject(internalUri)).toThrow(
       new Error(
-        `Unable to find the assigned URI for class http://example.org/.well-known/id/class/1 which acts as a parent.`,
+        `Unable to find the assigned URI for internal class urn:test:internal-class-id which acts as a parent.`,
       ),
     );
   });


### PR DESCRIPTION
Throw a warning for the `ParentURI` if it can't be resolved but it's external. Throw an `Error` if it's an internal URN and can't be resolved