### PR TITLE
Fix for `name` tag not being passed to the `NormalizedConnector` due to naming issues with tags array

### DIFF
--- a/packages/oslo-converter-uml-ea/lib/connector-normalisation-cases/AssociationWithDestinationRoleConnectorCase.ts
+++ b/packages/oslo-converter-uml-ea/lib/connector-normalisation-cases/AssociationWithDestinationRoleConnectorCase.ts
@@ -9,7 +9,11 @@ import { inject, injectable } from 'inversify';
 import { EaUmlConverterServiceIdentifier } from '../config/EaUmlConverterServiceIdentifier';
 import { TagNames } from '../enums/TagNames';
 import type { IConnectorNormalisationCase } from '../interfaces/IConnectorNormalisationCase';
-import { getTagValue, toCamelCase, updateNameTag } from '../utils/utils';
+import {
+  getTagValueFromArray,
+  formatLocalName,
+  updateNameTag,
+} from '../utils/utils';
 
 @injectable()
 export class AssociationWithDestinationRoleConnectorCase
@@ -38,9 +42,12 @@ export class AssociationWithDestinationRoleConnectorCase
       return [];
     }
 
-    const localName: string = toCamelCase(
-      getTagValue(connector.destinationRoleTags, TagNames.LocalName, null) ??
-        connector.destinationRole,
+    const localName: string = formatLocalName(
+      getTagValueFromArray(
+        connector.destinationRoleTags,
+        TagNames.LocalName,
+        null,
+      ) ?? connector.destinationRole,
     );
 
     const tags: EaTag[] = structuredClone(connector.destinationRoleTags);

--- a/packages/oslo-converter-uml-ea/lib/utils/utils.ts
+++ b/packages/oslo-converter-uml-ea/lib/utils/utils.ts
@@ -37,6 +37,28 @@ export function getTagValue(
   return tags[0].tagValue;
 }
 
+export function getTagValueFromArray(
+  tags: EaTag[] | undefined,
+  tagName: TagNames,
+  _default: any,
+): string {
+  if (!tags || tags.length === 0) {
+    return _default;
+  }
+
+  const matchingTags = tags.filter((x: EaTag) => x.tagName === tagName);
+
+  if (matchingTags.length === 0) {
+    return _default;
+  }
+
+  if (matchingTags.length > 1) {
+    // TODO: log message
+  }
+
+  return matchingTags[0].tagValue;
+}
+
 export function getDefininingPackageUri(
   uriRegistry: UriRegistry,
   packageName: string,
@@ -90,4 +112,24 @@ export function toCamelCase(text: string): string {
       index === 0 ? word.toLowerCase() : word.toUpperCase(),
     )
     .replace(/\s+/gu, '');
+}
+
+export function formatLocalName(name: string): string {
+  // If there's no dot, just use camelCase
+  if (!name.includes('.')) {
+    return toCamelCase(name);
+  }
+
+  // For Class.Property format, maintain PascalCase for class and camelCase for property
+  return name
+    .split('.')
+    .map((part, index) => {
+      if (index === 0) {
+        // First part (Class) should be PascalCase
+        return toPascalCase(part);
+      }
+      // Other parts (Property) should be camelCase
+      return toCamelCase(part);
+    })
+    .join('.');
 }

--- a/packages/oslo-converter-uml-ea/package.json
+++ b/packages/oslo-converter-uml-ea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/ea-converter",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Transform an Enterprise Architect UML diagram to RDF",
   "author": "Digitaal Vlaanderen <https://data.vlaanderen.be/id/organisatie/OVO002949>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-converter-uml-ea#readme",


### PR DESCRIPTION
* Created two new methods called `formatLocalName` and `getTagValueFromArray` specifically for this use-case. 
We could optimize the `getTagValue` method at some point to accept an array of tags instead of an object, but this was a better solution for now since it was only an issue here. 