### PR TITLE
oslo-validator-jsonld: allow accents for labels

### DIFF
--- a/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
+++ b/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
@@ -366,7 +366,7 @@ export class JsonldValidationService implements IService {
   }
 
   private checkIsAlphanumeric(value: string): boolean {
-    return value.match(/^[a-zA-Z0-9\s]+$/i) !== null;
+    return value.match(/^[a-z0-9éëïöü\s]+$/i) !== null;
   }
 
   private checkEndsWithHashOrDash(value: string): boolean {

--- a/packages/oslo-validator-jsonld/test/JsonldValidationService.unit.test.ts
+++ b/packages/oslo-validator-jsonld/test/JsonldValidationService.unit.test.ts
@@ -396,7 +396,7 @@ describe('JsonldValidationService', () => {
       ];
       jest.spyOn(store, 'findQuads').mockReturnValueOnce(nonMatchingQuads);
 
-      const result = (<any>service).validateSentences();
+      const result = (<any>service).validateLabels();
       expect(result.isValid).toBe(false);
 
       expect(result.invalidEntries).toHaveLength(2);
@@ -424,7 +424,7 @@ describe('JsonldValidationService', () => {
       ];
       jest.spyOn(store, 'findQuads').mockReturnValueOnce(nonMatchingQuads);
 
-      const result = (<any>service).validateSentences();
+      const result = (<any>service).validateLabels();
       expect(result.isValid).toBe(false);
 
       expect(result.invalidEntries).toHaveLength(2);
@@ -452,7 +452,7 @@ describe('JsonldValidationService', () => {
       ];
       jest.spyOn(store, 'findQuads').mockReturnValueOnce(nonMatchingQuads);
 
-      const result = (<any>service).validateSentences();
+      const result = (<any>service).validateLabels();
       expect(result.isValid).toBe(false);
 
       expect(result.invalidEntries).toHaveLength(2);
@@ -468,7 +468,7 @@ describe('JsonldValidationService', () => {
           df.namedNode(
             'https://implementatie.data.vlaanderen.be/ns/oslo-toolchain#apLabel',
           ),
-          df.literal('ap label'),
+          df.literal('ap label&'),
         ),
         df.quad(
           df.namedNode('http://subject/vocLabel'),
@@ -478,7 +478,7 @@ describe('JsonldValidationService', () => {
           df.literal('voc-label@'),
         ),
         df.quad(
-          df.namedNode('http://subject/vocLabel'),
+          df.namedNode('http://subject/accentLabel'),
           df.namedNode(
             'https://implementatie.data.vlaanderen.be/ns/oslo-toolchain#vocLabel',
           ),
@@ -487,7 +487,7 @@ describe('JsonldValidationService', () => {
       ];
       jest.spyOn(store, 'findQuads').mockReturnValueOnce(nonMatchingQuads);
 
-      const result = (<any>service).validateSentences();
+      const result = (<any>service).validateLabels();
       expect(result.isValid).toBe(false);
 
       expect(result.invalidEntries).toHaveLength(2);

--- a/packages/oslo-validator-jsonld/test/JsonldValidationService.unit.test.ts
+++ b/packages/oslo-validator-jsonld/test/JsonldValidationService.unit.test.ts
@@ -477,6 +477,13 @@ describe('JsonldValidationService', () => {
           ),
           df.literal('voc-label@'),
         ),
+        df.quad(
+          df.namedNode('http://subject/vocLabel'),
+          df.namedNode(
+            'https://implementatie.data.vlaanderen.be/ns/oslo-toolchain#vocLabel',
+          ),
+          df.literal('geïmplementeerd'),
+        ),
       ];
       jest.spyOn(store, 'findQuads').mockReturnValueOnce(nonMatchingQuads);
 


### PR DESCRIPTION
Fixes #166 