### PR TITLE
Validation fixes

### DIFF
--- a/packages/oslo-core/lib/enums/specificationType.ts
+++ b/packages/oslo-core/lib/enums/specificationType.ts
@@ -1,4 +1,4 @@
 export enum SpecificationType {
-  ApplicationProfile,
-  Vocabulary,
+  ApplicationProfile = 'ApplicationProfile',
+  Vocabulary = 'Vocabulary',
 }

--- a/packages/oslo-core/package.json
+++ b/packages/oslo-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/core",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Core interfaces and utilities",
   "author": "Digitaal Vlaanderen <https://data.vlaanderen.be/id/organisatie/OVO002949>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-core#readme",

--- a/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
+++ b/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
@@ -88,11 +88,11 @@ export class JsonldValidationService implements IService {
 
     if (resultMissingClasses.isValid) {
       this.logger.info(
-        'Validation successful! All referenced classes seem to be included.',
+        'Validation successful! All referenced classes and attributes seem to be included.',
       );
     } else {
       this.logger.info(
-        `Validation found ${resultMissingClasses.invalidEntries.length} missing referenced classes.`,
+        `Validation found ${resultMissingClasses.invalidEntries.length} missing referenced classes or attributes.`,
       );
     }
   }
@@ -387,10 +387,12 @@ export class JsonldValidationService implements IService {
               continue;
             }
 
-            this.logger.error(`Found missing class (${value}): ${uri}`);
+            this.logger.error(
+              `Found missing class or attribute (${value}): ${uri}`,
+            );
             result.invalidEntries.push({
               uri,
-              location: `Class (${value}) is missing: ${uri}`,
+              location: `Class or attribute (${value}) is missing: ${uri}`,
             });
             continue;
           }
@@ -415,10 +417,12 @@ export class JsonldValidationService implements IService {
               continue;
             }
 
-            this.logger.error(`Found missing class (${value}): ${uri}`);
+            this.logger.error(
+              `Found missing class or attribute (${value}): ${uri}`,
+            );
             result.invalidEntries.push({
               uri,
-              location: `Class (${value}) is missing: ${uri}`,
+              location: `Class or attribute (${value}) is missing: ${uri}`,
             });
             continue;
           }

--- a/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
+++ b/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
@@ -6,6 +6,7 @@ import {
   fetchFileOrUrl,
   ns,
   isStandardDatatype,
+  SpecificationType,
 } from '@oslo-flanders/core';
 import { inject, injectable } from 'inversify';
 import type * as RDF from '@rdfjs/types';
@@ -368,27 +369,63 @@ export class JsonldValidationService implements IService {
         const value: string = quad.object.value;
 
         // When classes with a diagramLabel do not have vocLabel, they will not show up in the HTML
-        if (this.store.getVocLabel(quad.subject, 'nl', null) === undefined) {
-          const assignedURI = this.store.findQuad(
-            quad.subject,
-            ns.oslo('assignedURI'),
-            null,
-          );
+        if (
+          this.configuration.specificationType === SpecificationType.Vocabulary
+        ) {
+          if (this.store.getVocLabel(quad.subject, 'nl', null) === undefined) {
+            const assignedURI = this.store.findQuad(
+              quad.subject,
+              ns.oslo('assignedURI'),
+              null,
+            );
 
-          // Skip XSD datatypes as they are never included in specifications
-          if (
-            assignedURI !== undefined &&
-            isStandardDatatype(assignedURI.object.value)
-          ) {
+            // Skip XSD datatypes as they are never included in specifications
+            if (
+              assignedURI !== undefined &&
+              isStandardDatatype(assignedURI.object.value)
+            ) {
+              continue;
+            }
+
+            this.logger.error(`Found missing class (${value}): ${uri}`);
+            result.invalidEntries.push({
+              uri,
+              location: `Class (${value}) is missing: ${uri}`,
+            });
             continue;
           }
+        } else if (
+          this.configuration.specificationType === SpecificationType.ApplicationProfile
+        ) {
+          if (
+            this.store.getApLabel(quad.subject, 'nl', null) === undefined &&
+            this.store.getVocLabel(quad.subject, 'nl', null) === undefined
+          ) {
+            const assignedURI = this.store.findQuad(
+              quad.subject,
+              ns.oslo('assignedURI'),
+              null,
+            );
 
-          this.logger.error(`Found missing class (${value}): ${uri}`);
-          result.invalidEntries.push({
-            uri,
-            location: `Class (${value}) is missing: ${uri}`,
-          });
-          continue;
+            // Skip XSD datatypes as they are never included in specifications
+            if (
+              assignedURI !== undefined &&
+              isStandardDatatype(assignedURI.object.value)
+            ) {
+              continue;
+            }
+
+            this.logger.error(`Found missing class (${value}): ${uri}`);
+            result.invalidEntries.push({
+              uri,
+              location: `Class (${value}) is missing: ${uri}`,
+            });
+            continue;
+          }
+        } else {
+          throw new Error(
+            `Unknown specification type: ${this.configuration.specificationType}`,
+          );
         }
       }
     }

--- a/packages/oslo-validator-jsonld/lib/JsonldValidationServiceRunner.ts
+++ b/packages/oslo-validator-jsonld/lib/JsonldValidationServiceRunner.ts
@@ -1,5 +1,5 @@
 import type { CliArgv } from '@oslo-flanders/core';
-import { AppRunner } from '@oslo-flanders/core';
+import { AppRunner, SpecificationType } from '@oslo-flanders/core';
 import yargs from 'yargs';
 import { container } from './config/DependencyInjectionConfig';
 import type { JsonldValidationServiceConfiguration } from './config/JsonldValidationServiceConfiguration';
@@ -14,6 +14,13 @@ export class JsonldValidationServiceRunner extends AppRunner<
       .usage('node ./bin/runner.js [args]')
       .option('input', {
         describe: 'Local path or URL to JSON-LD file to validate.',
+      })
+      .option('specificationType', {
+        describe: 'Type of the document.',
+        choices: [
+          SpecificationType.ApplicationProfile,
+          SpecificationType.Vocabulary,
+        ],
       })
       .option('whitelist', {
         describe:

--- a/packages/oslo-validator-jsonld/lib/config/JsonldValidationServiceConfiguration.ts
+++ b/packages/oslo-validator-jsonld/lib/config/JsonldValidationServiceConfiguration.ts
@@ -13,9 +13,15 @@ export class JsonldValidationServiceConfiguration implements IConfiguration {
    */
   private _whitelist: string | undefined;
 
+  /**
+   * Type of document
+   */
+  private _specificationType: string | undefined;
+
   public async createFromCli(params: YargsParams): Promise<void> {
     this._input = <string>params.input;
     this._whitelist = <string>params.whitelist;
+    this._specificationType = <string>params.specificationType;
   }
 
   public get input(): string {
@@ -27,5 +33,9 @@ export class JsonldValidationServiceConfiguration implements IConfiguration {
 
   public get whitelist(): string | undefined {
     return this._whitelist;
+  }
+
+  public get specificationType(): string | undefined {
+    return this._specificationType;
   }
 }

--- a/packages/oslo-validator-jsonld/package.json
+++ b/packages/oslo-validator-jsonld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/jsonld-validator",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Validates the generated JSON-LD file to a set of validation rules",
   "author": "Digitaal Vlaanderen <https://data.vlaanderen.be/id/organisatie/OVO002949>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-validator-jsonld#readme",

--- a/packages/oslo-validator-jsonld/test/JsonldValidationService.unit.test.ts
+++ b/packages/oslo-validator-jsonld/test/JsonldValidationService.unit.test.ts
@@ -31,6 +31,7 @@ describe('JsonldValidationService', () => {
     config = new JsonldValidationServiceConfiguration();
     (<any>config)._input = 'input.jsonld';
     (<any>config)._whitelist = 'whitelist.json';
+    (<any>config)._specificationType = 'ApplicationProfile';
 
     store = new QuadStore();
 


### PR DESCRIPTION
See commits:

- `specificationType` CLI arg was not defined in the help method of OSLO's UML EA convertor.
- Added the same parameter for OSLO's JSONLD validator because missing classes detection may depend on the type of specification.
- Improved missing classes error message because attributes can also be detected.