### PR TITLE
fix: oslo-validator-jsonld: improve error message

### DIFF
--- a/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
+++ b/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
@@ -388,7 +388,7 @@ export class JsonldValidationService implements IService {
             }
 
             this.logger.error(
-              `Found missing class or attribute (${value}): ${uri}`,
+              `Found missing class or attribute (${value}): ${uri} in Vocabulary`,
             );
             result.invalidEntries.push({
               uri,
@@ -418,7 +418,7 @@ export class JsonldValidationService implements IService {
             }
 
             this.logger.error(
-              `Found missing class or attribute (${value}): ${uri}`,
+              `Found missing class or attribute (${value}): ${uri} in Application Profile`,
             );
             result.invalidEntries.push({
               uri,

--- a/packages/oslo-validator-jsonld/package.json
+++ b/packages/oslo-validator-jsonld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/jsonld-validator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Validates the generated JSON-LD file to a set of validation rules",
   "author": "Digitaal Vlaanderen <https://data.vlaanderen.be/id/organisatie/OVO002949>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-validator-jsonld#readme",


### PR DESCRIPTION
Specify specification type since different rules apply for the same error