### PR TITLE
fix(oslo-validator-jsonld): filter assignedURIs by voc

### DIFF
--- a/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
+++ b/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
@@ -379,6 +379,16 @@ export class JsonldValidationService implements IService {
               null,
             );
 
+            // Skip URIs which are not in the vocabulary, they are checked in the application profile
+            if (
+              assignedURI !== undefined &&
+              assignedURI.value.includes(
+                this.configuration.publicationEnvironment,
+              )
+            ) {
+              continue;
+            }
+
             // Skip XSD datatypes as they are never included in specifications
             if (
               assignedURI !== undefined &&
@@ -397,7 +407,8 @@ export class JsonldValidationService implements IService {
             continue;
           }
         } else if (
-          this.configuration.specificationType === SpecificationType.ApplicationProfile
+          this.configuration.specificationType ===
+          SpecificationType.ApplicationProfile
         ) {
           if (
             this.store.getApLabel(quad.subject, 'nl', null) === undefined &&

--- a/packages/oslo-validator-jsonld/lib/JsonldValidationServiceRunner.ts
+++ b/packages/oslo-validator-jsonld/lib/JsonldValidationServiceRunner.ts
@@ -13,6 +13,9 @@ export class JsonldValidationServiceRunner extends AppRunner<
       .option('input', {
         describe: 'Local path or URL to JSON-LD file to validate.',
       })
+      .option('publicationEnvironment', {
+        describe: 'The base URI of environment where the document will be published.',
+      })
       .option('specificationType', {
         describe: 'Type of the document.',
         choices: [

--- a/packages/oslo-validator-jsonld/lib/config/JsonldValidationServiceConfiguration.ts
+++ b/packages/oslo-validator-jsonld/lib/config/JsonldValidationServiceConfiguration.ts
@@ -9,6 +9,11 @@ export class JsonldValidationServiceConfiguration implements IConfiguration {
   private _input: string | undefined;
 
   /**
+   * The base URI of the environment where the document will be published
+   */
+  private _publicationEnvironment: string | undefined;
+
+  /**
    * Local path or URL to whitelist file (JSON array of URI prefixes)
    */
   private _whitelist: string | undefined;
@@ -20,22 +25,44 @@ export class JsonldValidationServiceConfiguration implements IConfiguration {
 
   public async createFromCli(params: YargsParams): Promise<void> {
     this._input = <string>params.input;
+    this._publicationEnvironment = <string>params.publicationEnvironment;
     this._whitelist = <string>params.whitelist;
     this._specificationType = <string>params.specificationType;
   }
 
   public get input(): string {
     if (!this._input) {
-      throw new Error(`Trying to access property "input" before it was set.`);
+      throw new Error(
+        `Trying to access property "input" before it was set.`,
+      );
     }
     return this._input;
   }
 
   public get whitelist(): string | undefined {
+    if (!this._whitelist) {
+      throw new Error(
+        `Trying to access property "whitelist" before it was set.`,
+      );
+    }
     return this._whitelist;
   }
 
   public get specificationType(): string | undefined {
+    if (!this._specificationType) {
+      throw new Error(
+        `Trying to access property "specificationType" before it was set.`,
+      );
+    }
     return this._specificationType;
+  }
+
+  public get publicationEnvironment(): string {
+    if (!this._publicationEnvironment) {
+      throw new Error(
+        `Trying to access property "publicationEnvironment" before it was set.`,
+      );
+    }
+    return this._publicationEnvironment;
   }
 }

--- a/packages/oslo-validator-jsonld/package.json
+++ b/packages/oslo-validator-jsonld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/jsonld-validator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Validates the generated JSON-LD file to a set of validation rules",
   "author": "Digitaal Vlaanderen <https://data.vlaanderen.be/id/organisatie/OVO002949>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-validator-jsonld#readme",


### PR DESCRIPTION
Only check missing classes or attributes if they are part of the voc