### PR TITLE
fix(oslo-generator-shacl-template): do not enforce type for skos:Concept

### DIFF
--- a/packages/oslo-generator-shacl-template/lib/constants/filteredUris.ts
+++ b/packages/oslo-generator-shacl-template/lib/constants/filteredUris.ts
@@ -5,7 +5,7 @@ import type * as RDF from '@rdfjs/types';
  * URIs that should be filtered out from SHACL shape generation
  */
 
-export const FILTERED_URIS: RDF.NamedNode[] = [ns.rdfs('Literal')];
+export const FILTERED_URIS: RDF.NamedNode[] = [ns.rdfs('Literal'), ns.skos('Concept')];
 
 /**
  * Check if a URI should be filtered out from shape generation

--- a/packages/oslo-generator-shacl-template/lib/handlers/PropertyShapeBaseHandler.ts
+++ b/packages/oslo-generator-shacl-template/lib/handlers/PropertyShapeBaseHandler.ts
@@ -115,7 +115,10 @@ export class PropertyShapeBaseHandler extends ShaclHandler {
 
     if (shouldFilterUri(rangeAssignedURI)) {
       propertyTypePredicate = ns.shacl('nodeKind');
-      propertyTypeValue = ns.shacl('Literal');
+      propertyTypeValue =
+        ns.rdfs('Literal').value == rangeAssignedURI.value
+          ? ns.shacl('Literal')
+          : ns.shacl('BlankNodeOrIRI');
     } else {
       propertyTypePredicate = propertyType.equals(ns.owl('DatatypeProperty'))
         ? ns.shacl('datatype')
@@ -176,7 +179,7 @@ export class PropertyShapeBaseHandler extends ShaclHandler {
         this.df.quad(
           shapeId,
           propertyTypePredicate,
-          rangeAssignedURI.equals(ns.rdfs('Literal'))
+          (rangeAssignedURI.equals(ns.rdfs('Literal')) || rangeAssignedURI.equals(ns.skos('Concept')))
             ? propertyTypeValue
             : rangeAssignedURI,
           baseQuadsGraph,

--- a/packages/oslo-generator-shacl-template/package.json
+++ b/packages/oslo-generator-shacl-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/shacl-template-generator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Generates a SHACL template based on an OSLO JSON-LD file",
   "author": "Dwight Van Lancker <dwight.vanlancker@vlaanderen.be>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-generator-shacl-template#readme",


### PR DESCRIPTION
Concepts are linked mostly, do not require type.