### PR TITLE
XSD language

### DIFF
--- a/packages/oslo-core/lib/enums/DataTypes.ts
+++ b/packages/oslo-core/lib/enums/DataTypes.ts
@@ -35,6 +35,7 @@ export const DataTypes: Map<string, string> = new Map<string, string>([
   ['unsignedshort', `${xsd}#unsignedLong`],
   ['unsignedshort', `${xsd}#unsignedShort`],
   ['unsignedbyte', `${xsd}#unsignedByte`],
+  ['language', `${xsd}#language`],
 ]);
 
 export const getDataType = (key: string): string | undefined =>

--- a/packages/oslo-core/package.json
+++ b/packages/oslo-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/core",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Core interfaces and utilities",
   "author": "Digitaal Vlaanderen <https://data.vlaanderen.be/id/organisatie/OVO002949>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-core#readme",

--- a/packages/oslo-generator-swagger/lib/enums/Properties.ts
+++ b/packages/oslo-generator-swagger/lib/enums/Properties.ts
@@ -28,6 +28,7 @@ const Properties: Map<string, object> = new Map<string, object>([
   [ns.xsd('unsignedShort').value, { '@value': { type: 'number', format: 'int32', minimum: 0, maximum: 65_535 }, '@type': { type: 'string', pattern: '^UnsignedShort$' } }],
   [ns.xsd('unsignedByte').value, { '@value': { type: 'number', format: 'int32', minimum: 0, maximum: 255 }, '@type': { type: 'string', pattern: '^UnsignedByte$' } }],
   [ns.xsd('decimal').value, { '@value': { type: 'string', pattern: '(+|-)?([0-9]+(.[0-9]*)?|.[0-9]+)' }, '@type': { type: 'string', pattern: '^Decimal$' } }],
+  [ns.xsd('language').value, { '@value': { type: 'string', pattern: '^[a-z]{2,3}(-[A-Z]{2})?' }, '@type': { type: 'string', pattern: '^Language$' } }],
 ]);
 /* eslint-enable max-len*/
 

--- a/packages/oslo-generator-swagger/package.json
+++ b/packages/oslo-generator-swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/swagger-generator",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Generate OpenAPI Swagger YAML documentation.",
   "author": "Digitaal Vlaanderen <https://data.vlaanderen.be/id/organisatie/OVO002949>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-generator-swagger#readme",


### PR DESCRIPTION
XSD language is a primitive type to indicate that a Literal must be a valid language tag following BCP47/ISO639