### PR TITLE
fix: oslo-jsonld-validator: fix for `--language` not being an option …

### DIFF
--- a/packages/oslo-validator-jsonld/README.md
+++ b/packages/oslo-validator-jsonld/README.md
@@ -20,14 +20,17 @@ npm install -g @oslo-flanders/jsonld-validator
 
 ## API
 
-| Parameter     | Description                                                                             | Required           | Possible values  |
-| ------------- | --------------------------------------------------------------------------------------- | ------------------ | ---------------- |
-| `--input`     | The URL or local file path of an OSLO JSON-LD file                                      | :heavy_check_mark: |                  |
-| `--whitelist` | The URL or local file path to a whitelist json containing a set of allowed URI prefixes | :heavy_check_mark: | `whitelist.json` |
+| Parameter                  | Description                                                                             | Required           | Possible values                    |
+| -------------------------- | --------------------------------------------------------------------------------------- | ------------------ | ---------------------------------- |
+| `--input`                  | The URL or local file path of an OSLO JSON-LD file                                      | :heavy_check_mark: |                                    |
+| `--whitelist`              | The URL or local file path to a whitelist json containing a set of allowed URI prefixes | :heavy_check_mark: | `whitelist.json`                   |
+| `--publicationEnvironment` | The base URI of environment where the document will be published.                       | :heavy_check_mark: | `https://data.vlaanderen.be`       |
+| `--language`               | The language in which intermediary format is generated.                                 | :heavy_check_mark: | `nl`, `fr`, `en`, `es`             |
+| `--specificationType`      | The type of specification being validated.                                              | :heavy_check_mark: | `ApplicationProfile`, `Vocabulary` |
 
 ## Usage
 
 ```bash
-oslo-jsonld-validator --input report.jsonld --whitelist whitelist.json
-oslo-jsonld-validator --input report.jsonld --whitelist https://raw.githubusercontent.com/Informatievlaanderen/OSLO-UML-Transformer/refs/heads/configuration/whitelist.json
+oslo-jsonld-validator --input report.jsonld --whitelist whitelist.json --language nl --publicationEnvironment https://data.vlaanderen.be --specificationType Vocabulary
+oslo-jsonld-validator --input report.jsonld --whitelist https://raw.githubusercontent.com/Informatievlaanderen/OSLO-UML-Transformer/refs/heads/configuration/whitelist.json --language nl --publicationEnvironment https://data.vlaanderen.be --specificationType ApplicationProfile
 ```

--- a/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
+++ b/packages/oslo-validator-jsonld/lib/JsonldValidationService.ts
@@ -402,7 +402,7 @@ export class JsonldValidationService implements IService {
         if (
           this.configuration.specificationType === SpecificationType.Vocabulary
         ) {
-          if (this.store.getVocLabel(quad.subject, 'nl', null) === undefined) {
+          if (this.store.getVocLabel(quad.subject, this.configuration.language, null) === undefined) {
             const assignedURI = this.store.findQuad(
               quad.subject,
               ns.oslo('assignedURI'),
@@ -441,8 +441,8 @@ export class JsonldValidationService implements IService {
           SpecificationType.ApplicationProfile
         ) {
           if (
-            this.store.getApLabel(quad.subject, 'nl', null) === undefined &&
-            this.store.getVocLabel(quad.subject, 'nl', null) === undefined
+            this.store.getApLabel(quad.subject, this.configuration.language, null) === undefined &&
+            this.store.getVocLabel(quad.subject, this.configuration.language, null) === undefined
           ) {
             const assignedURI = this.store.findQuad(
               quad.subject,

--- a/packages/oslo-validator-jsonld/lib/JsonldValidationServiceRunner.ts
+++ b/packages/oslo-validator-jsonld/lib/JsonldValidationServiceRunner.ts
@@ -27,7 +27,11 @@ export class JsonldValidationServiceRunner extends AppRunner<
         describe:
           'Local path or URL to whitelist file (JSON array of URI prefixes).',
       })
-      .demandOption(['input', 'publicationEnvironment', 'whitelist'])
+      .option('language', {
+        describe: 'The language in which intermediary format is generated.',
+        default: 'nl'
+      })
+      .demandOption(['input', 'publicationEnvironment', 'whitelist', 'language'])
       .help('h')
       .alias('h', 'help');
 

--- a/packages/oslo-validator-jsonld/lib/config/JsonldValidationServiceConfiguration.ts
+++ b/packages/oslo-validator-jsonld/lib/config/JsonldValidationServiceConfiguration.ts
@@ -23,11 +23,17 @@ export class JsonldValidationServiceConfiguration implements IConfiguration {
    */
   private _specificationType: string | undefined;
 
+  /**
+   * The language in which intermediary format is generated
+   */
+  private _language: string | undefined;
+
   public async createFromCli(params: YargsParams): Promise<void> {
     this._input = <string>params.input;
     this._publicationEnvironment = <string>params.publicationEnvironment;
     this._whitelist = <string>params.whitelist;
     this._specificationType = <string>params.specificationType;
+    this._language = <string>params.language
   }
 
   public get input(): string {
@@ -65,4 +71,14 @@ export class JsonldValidationServiceConfiguration implements IConfiguration {
     }
     return this._publicationEnvironment;
   }
+
+  public get language(): string {
+    if (!this._language) {
+      throw new Error(
+        `Trying to access property "language" before it was set.`,
+      );
+    }
+    return this._language;
+  }
 }
+

--- a/packages/oslo-validator-jsonld/package.json
+++ b/packages/oslo-validator-jsonld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oslo-flanders/jsonld-validator",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Validates the generated JSON-LD file to a set of validation rules",
   "author": "Digitaal Vlaanderen <https://data.vlaanderen.be/id/organisatie/OVO002949>",
   "homepage": "https://github.com/informatievlaanderen/OSLO-UML-Transformer/tree/main/packages/oslo-validator-jsonld#readme",

--- a/packages/oslo-validator-jsonld/test/JsonldValidationService.unit.test.ts
+++ b/packages/oslo-validator-jsonld/test/JsonldValidationService.unit.test.ts
@@ -32,6 +32,7 @@ describe('JsonldValidationService', () => {
     (<any>config)._input = 'input.jsonld';
     (<any>config)._whitelist = 'whitelist.json';
     (<any>config)._specificationType = 'ApplicationProfile';
+    (<any>config)._language = 'nl';
 
     store = new QuadStore();
 


### PR DESCRIPTION
…in the `oslo-jsonld-validator` causing issues with multilang models